### PR TITLE
Some improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Scott Hutton <shutton@pobox.com>"]
 edition = "2018"
 description = "Interface to Webex Teams REST and WebSocket APIs"

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -18,19 +18,22 @@ pub struct AdaptiveCard {
     /// Maximum version is 1.1
     pub version: String,
     /// The card elements to show in the primary card region.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Vec<CardElement>>,
     /// Actions available for this card
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub actions: Option<Vec<Action>>,
     /// An Action that will be invoked when the card is tapped or selected.
-    #[serde(rename = "selectAction")]
+    #[serde(rename = "selectAction", skip_serializing_if = "Option::is_none")]
     pub select_action: Option<Box<Action>>,
     /// Text shown when the client doesn’t support the version specified (may contain markdown).
-    #[serde(rename = "fallbackText")]
+    #[serde(rename = "fallbackText", skip_serializing_if = "Option::is_none")]
     pub fallback_text: Option<String>,
     /// Specifies the minimum height of the card.
-    #[serde(rename = "minHeight")]
+    #[serde(rename = "minHeight", skip_serializing_if = "Option::is_none")]
     pub min_height: Option<String>,
     /// The 2-letter ISO-639-1 language used in the card. Used to localize any date/time functions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lang: Option<String>,
     /// The Adaptive Card schema.
     /// http://adaptivecards.io/schemas/adaptive-card.json
@@ -108,20 +111,25 @@ pub enum CardElement {
         /// The card elements to render inside the Container.
         items: Vec<CardElement>,
         /// An Action that will be invoked when the Container is tapped or selected.
-        #[serde(rename = "selectAction")]
+        #[serde(rename = "selectAction", skip_serializing_if = "Option::is_none")]
         select_action: Option<Action>,
         /// Style hint for Container.
+        #[serde(skip_serializing_if = "Option::is_none")]
         style: Option<ContainerStyle>,
         /// Defines how the content should be aligned vertically within the container.
-        #[serde(rename = "verticalContentAlignment")]
+        #[serde(rename = "verticalContentAlignment", skip_serializing_if = "Option::is_none")]
         vertical_content_alignment: Option<VerticalContentAlignment>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// A unique identifier associated with the item.
+        #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -130,15 +138,16 @@ pub enum CardElement {
         /// The array of Columns to divide the region into.
         columns: Vec<Column>,
         /// An Action that will be invoked when the ColumnSet is tapped or selected.
-        #[serde(rename = "selectAction")]
+        #[serde(rename = "selectAction", skip_serializing_if = "Option::is_none")]
         select_action: Option<Action>,
-        /// Specifies the height of the element.
-        height: Option<Height>,
         /// A unique identifier associated with the item.
+        #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -147,12 +156,16 @@ pub enum CardElement {
         /// 	The array of Fact‘s.
         facts: Vec<Fact>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// A unique identifier associated with the item.
+        #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -161,15 +174,19 @@ pub enum CardElement {
         /// The array of Image elements to show.
         images: Vec<CardElement>,
         /// Controls the approximate size of each image. The physical dimensions will vary per host.
-        #[serde(rename = "imageSize")]
+        #[serde(rename = "imageSize", skip_serializing_if = "Option::is_none")]
         image_size: Option<ImageSize>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// A unique identifier associated with the item.
+        #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -178,32 +195,40 @@ pub enum CardElement {
         /// Text to display
         text: String,
         /// If true, allow text to wrap. Otherwise, text is clipped.
+        #[serde(skip_serializing_if = "Option::is_none")]
         wrap: Option<bool>,
         /// Controls the color of TextBlock elements.
+        #[serde(skip_serializing_if = "Option::is_none")]
         color: Option<Color>,
         /// Controls the horizontal text alignment.
-        #[serde(rename = "HorizontalAlignment")]
+        #[serde(rename = "HorizontalAlignment", skip_serializing_if = "Option::is_none")]
         horizontal_alignment: Option<HorizontalAlignment>,
         /// If true, displays text slightly toned down to appear less prominent.
-        #[serde(rename = "isSubtle")]
+        #[serde(rename = "isSubtle", skip_serializing_if = "Option::is_none")]
         is_subtle: Option<bool>,
         /// Specifies the maximum number of lines to display.
-        #[serde(rename = "maxLines")]
+        #[serde(rename = "maxLines", skip_serializing_if = "Option::is_none")]
         max_lines: Option<u64>,
         /// Specifies the font type
-        #[serde(rename = "fontType")]
+        #[serde(rename = "fontType", skip_serializing_if = "Option::is_none")]
         font_type: Option<FontType>,
         /// Controls size of text.
+        #[serde(skip_serializing_if = "Option::is_none")]
         size: Option<Size>,
         /// Controls the weight of TextBlock elements.
+        #[serde(skip_serializing_if = "Option::is_none")]
         weight: Option<Weight>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// A unique identifier associated with the item.
+        #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -212,31 +237,38 @@ pub enum CardElement {
         /// The URL to the image.
         url: String,
         /// Alternate text describing the image.
-        #[serde(rename = "altText")]
+        #[serde(rename = "altText", skip_serializing_if = "Option::is_none")]
         alt_text: Option<String>,
         /// Applies a background to a transparent image. This property will respect the image style.
         /// hex value of a color (e.g. #982374)
-        #[serde(rename = "backgroundColor")]
+        #[serde(rename = "backgroundColor", skip_serializing_if = "Option::is_none")]
         background_color: Option<String>,
         /// The desired on-screen width of the image, ending in ‘px’. E.g., 50px. This overrides the size property.
+        #[serde(skip_serializing_if = "Option::is_none")]
         width: Option<String>,
         /// The desired height of the image. If specified as a pixel value, ending in ‘px’, E.g., 50px, the image will distort to fit that exact height. This overrides the size property.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<String>,
         /// Controls how this element is horizontally positioned within its parent.
-        #[serde(rename = "horizontalAlignment")]
+        #[serde(rename = "horizontalAlignment", skip_serializing_if = "Option::is_none")]
         horizontal_alignment: Option<HorizontalAlignment>,
         /// An Action that will be invoked when the Image is tapped or selected. Action.ShowCard is not supported.
-        #[serde(rename = "selectAction")]
+        #[serde(rename = "selectAction", skip_serializing_if = "Option::is_none")]
         select_action: Option<Action>,
         /// Controls the approximate size of the image. The physical dimensions will vary per host.
+        #[serde(skip_serializing_if = "Option::is_none")]
         size: Option<ImageSize>,
         /// Controls how this Image is displayed.
+        #[serde(skip_serializing_if = "Option::is_none")]
         style: Option<ImageStyle>,
         /// A unique identifier associated with the item.
+        #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -246,25 +278,31 @@ pub enum CardElement {
         /// Unique identifier for the value. Used to identify collected input when the Submit action is performed.
         id: String,
         /// Description of the input desired. Displayed when no text has been input.
+        #[serde(skip_serializing_if = "Option::is_none")]
         placeholder: Option<String>,
         /// If true, allow multiple lines of input.
-        #[serde(rename = "isMultiline")]
+        #[serde(rename = "isMultiline", skip_serializing_if = "Option::is_none")]
         is_multiline: Option<bool>,
         /// Hint of maximum length characters to collect (may be ignored by some clients).
-        #[serde(rename = "maxLength")]
+        #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
         max_length: Option<u64>,
         /// Text Input Style
+        #[serde(skip_serializing_if = "Option::is_none")]
         style: Option<TextInputStyle>,
         /// The inline action for the input. Typically displayed to the right of the input.
-        #[serde(rename = "inlineAction")]
+        #[serde(rename = "inlineAction", skip_serializing_if = "Option::is_none")]
         inline_action: Option<Action>,
         /// The initial value for this field.
+        #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -274,18 +312,25 @@ pub enum CardElement {
         /// Unique identifier for the value. Used to identify collected input when the Submit action is performed.
         id: String,
         /// Description of the input desired. Displayed when no selection has been made.
+        #[serde(skip_serializing_if = "Option::is_none")]
         placeholder: Option<String>,
         /// Hint of maximum value (may be ignored by some clients).
+        #[serde(skip_serializing_if = "Option::is_none")]
         max: Option<f64>,
         /// Hint of minimum value (may be ignored by some clients).
+        #[serde(skip_serializing_if = "Option::is_none")]
         min: Option<f64>,
         /// Initial value for this field.
+        #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<f64>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -295,18 +340,25 @@ pub enum CardElement {
         /// Unique identifier for the value. Used to identify collected input when the Submit action is performed.
         id: String,
         /// Description of the input desired. Displayed when no selection has been made.
+        #[serde(skip_serializing_if = "Option::is_none")]
         placeholder: Option<String>,
         /// Hint of maximum value expressed in YYYY-MM-DD(may be ignored by some clients).
+        #[serde(skip_serializing_if = "Option::is_none")]
         max: Option<String>,
         /// Hint of minimum value expressed in YYYY-MM-DD(may be ignored by some clients).
+        #[serde(skip_serializing_if = "Option::is_none")]
         min: Option<String>,
         /// The initial value for this field expressed in YYYY-MM-DD.
+        #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -316,16 +368,22 @@ pub enum CardElement {
         /// Unique identifier for the value. Used to identify collected input when the Submit action is performed.
         id: String,
         /// Hint of maximum value expressed in HH:MM (may be ignored by some clients).
+        #[serde(skip_serializing_if = "Option::is_none")]
         max: Option<String>,
         /// Hint of minimum value expressed in HH:MM (may be ignored by some clients).
+        #[serde(skip_serializing_if = "Option::is_none")]
         min: Option<String>,
         /// The initial value for this field expressed in HH:MM.
+        #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -335,18 +393,22 @@ pub enum CardElement {
         /// Unique identifier for the value. Used to identify collected input when the Submit action is performed.
         id: String,
         /// The initial selected value. If you want the toggle to be initially on, set this to the value of valueOn‘s value.
+        #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
         /// The value when toggle is off
-        #[serde(rename = "valueOff")]
+        #[serde(rename = "valueOff", skip_serializing_if = "Option::is_none")]
         value_off: Option<String>,
         /// The value when toggle is on
-        #[serde(rename = "valueOn")]
+        #[serde(rename = "valueOn", skip_serializing_if = "Option::is_none")]
         value_on: Option<String>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -358,17 +420,22 @@ pub enum CardElement {
         /// Unique identifier for the value. Used to identify collected input when the Submit action is performed.
         id: String,
         /// Allow multiple choices to be selected.
-        #[serde(rename = "isMultiSelect")]
+        #[serde(rename = "isMultiSelect", skip_serializing_if = "Option::is_none")]
         is_multi_select: Option<bool>,
         /// Input Choice Style
+        #[serde(skip_serializing_if = "Option::is_none")]
         style: Option<ChoiceInputStyle>,
         /// The initial choice (or set of choices) that should be selected. For multi-select, specify a comma-separated string of values.
+        #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<String>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
         /// When true, draw a separating line at the top of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<bool>,
         /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
     },
 
@@ -377,6 +444,7 @@ pub enum CardElement {
         /// The array of Action elements to show.
         actions: Vec<Action>,
         /// Specifies the height of the element.
+        #[serde(skip_serializing_if = "Option::is_none")]
         height: Option<Height>,
     },
 }
@@ -446,7 +514,7 @@ impl CardElement {
     /// Set Text Input Multiline
     pub fn set_multiline(&mut self, s: bool) -> Self {
         if let CardElement::InputText {
-            id:_, placeholder:_, is_multiline, max_length:_, style:_, inline_action:_, value:_, height:_, separator:_, spacing:_
+            id: _, placeholder: _, is_multiline, max_length: _, style: _, inline_action: _, value: _, height: _, separator: _, spacing: _
         } = self { *is_multiline = Some(s); }
         self.into()
     }
@@ -613,7 +681,6 @@ impl CardElement {
         CardElement::ColumnSet {
             columns: vec![],
             select_action: None,
-            height: None,
             id: None,
             separator: None,
             spacing: None,
@@ -624,7 +691,7 @@ impl CardElement {
     pub fn add_column(&mut self, column: Column) -> Self {
         match self {
             CardElement::ColumnSet {
-                columns, select_action: _, height: _, id: _, separator: _, spacing: _
+                columns, select_action: _, id: _, separator: _, spacing: _
             } => { columns.push(column) }
             _ => {}
         }
@@ -640,7 +707,7 @@ impl CardElement {
             CardElement::FactSet {
                 facts: _, height: _, id: _, separator, spacing: _, } => { *separator = Some(s); }
             CardElement::ColumnSet {
-                columns: _, select_action: _, height: _, id: _, separator, spacing: _
+                columns: _, select_action: _, id: _, separator, spacing: _
             } => { *separator = Some(s); }
             CardElement::Image {
                 url: _, alt_text: _, background_color: _, width: _, height: _, horizontal_alignment: _, select_action: _, size: _, style: _, id: _, separator, spacing: _
@@ -666,7 +733,7 @@ impl CardElement {
                 facts: _, height: _, id: _, separator: _, spacing,
             } => { *spacing = Some(s); }
             CardElement::ColumnSet {
-                columns: _, select_action: _, height: _, id: _, separator: _, spacing
+                columns: _, select_action: _, id: _, separator: _, spacing
             } => { *spacing = Some(s); }
             CardElement::Image {
                 url: _, alt_text: _, background_color: _, width: _, height: _, horizontal_alignment: _, select_action: _, size: _, style: _, id: _, separator: _, spacing
@@ -708,20 +775,25 @@ pub struct Column {
     /// The card elements to render inside the Column.
     items: Vec<CardElement>,
     /// An Action that will be invoked when the Column is tapped or selected.
-    #[serde(rename = "selectAction")]
+    #[serde(rename = "selectAction", skip_serializing_if = "Option::is_none")]
     select_action: Option<Action>,
     /// Style hint for Column.
+    #[serde(skip_serializing_if = "Option::is_none")]
     style: Option<ContainerStyle>,
     /// Defines how the content should be aligned vertically within the column.
-    #[serde(rename = "verticalContentAlignment")]
+    #[serde(rename = "verticalContentAlignment", skip_serializing_if = "Option::is_none")]
     vertical_content_alignment: Option<VerticalContentAlignment>,
     /// When true, draw a separating line between this column and the previous column.
+    #[serde(skip_serializing_if = "Option::is_none")]
     separator: Option<bool>,
     /// Controls the amount of spacing between this column and the preceding column.
+    #[serde(skip_serializing_if = "Option::is_none")]
     spacing: Option<Spacing>,
     /// "auto", "stretch", a number representing relative width of the column in the column group, or in version 1.1 and higher, a specific pixel width, like "50px".
+    #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<String>,
     /// A unique identifier associated with the item.
+    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<String>,
 }
 
@@ -923,10 +995,13 @@ pub enum Action {
     #[serde(rename = "Action.Submit")]
     Submit {
         /// Initial data that input fields will be combined with. These are essentially ‘hidden’ properties.
+        #[serde(skip_serializing_if = "Option::is_none")]
         data: Option<HashMap<String, String>>,
         /// Label for button or link that represents this action.
+        #[serde(skip_serializing_if = "Option::is_none")]
         title: Option<String>,
         /// Controls the style of an Action, which influences how the action is displayed, spoken, etc.
+        #[serde(skip_serializing_if = "Option::is_none")]
         style: Option<ActionStyle>,
     },
     /// When invoked, show the given url either by launching it in an external web browser or showing within an embedded web browser.
@@ -935,8 +1010,10 @@ pub enum Action {
         /// The URL to open.
         url: String,
         /// Label for button or link that represents this action.
+        #[serde(skip_serializing_if = "Option::is_none")]
         title: Option<String>,
         /// Controls the style of an Action, which influences how the action is displayed, spoken, etc.
+        #[serde(skip_serializing_if = "Option::is_none")]
         style: Option<ActionStyle>,
     },
     /// Defines an AdaptiveCard which is shown to the user when the button or link is clicked.
@@ -945,8 +1022,10 @@ pub enum Action {
         /// The Adaptive Card to show.
         card: AdaptiveCard,
         /// Label for button or link that represents this action.
+        #[serde(skip_serializing_if = "Option::is_none")]
         title: Option<String>,
         /// Controls the style of an Action, which influences how the action is displayed, spoken, etc.
+        #[serde(skip_serializing_if = "Option::is_none")]
         style: Option<ActionStyle>,
     },
 }

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -410,6 +410,9 @@ pub enum CardElement {
         /// Controls the amount of spacing between this element and the preceding element.
         #[serde(skip_serializing_if = "Option::is_none")]
         spacing: Option<Spacing>,
+        /// Controls the amount of spacing between this element and the preceding element.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
     },
 
     /// Allows a user to input a Choice.
@@ -543,6 +546,7 @@ impl CardElement {
             height: None,
             separator: None,
             spacing: None,
+            title: None
         }
     }
 
@@ -551,6 +555,14 @@ impl CardElement {
         if let CardElement::InputChoiceSet {
             choices: _, id: _, is_multi_select: _, style, value: _, height: _, separator: _, spacing: _
         } = self { *style = Some(s); }
+        self.into()
+    }
+
+    /// Set title Style
+    pub fn set_title(&mut self, s: String) -> Self {
+        if let CardElement::InputToggle {
+            id: _id, value: _value, value_off: _value_off, value_on: _value_on, height: _height, separator: _separator, spacing: _spacing, title
+        } = self { *title = Some(s); }
         self.into()
     }
 
@@ -718,6 +730,7 @@ impl CardElement {
             CardElement::InputText {
                 id: _, placeholder: _, is_multiline: _, max_length: _, style: _, inline_action: _, value: _, height: _, separator, spacing: _
             } => { *separator = Some(s); }
+            CardElement::InputToggle { id: _id, value: _value, value_off: _value_off, value_on: _value_on, height: _height, separator, spacing: _spacing, title: _title } => { *separator = Some(s); }
             _ => {}
         }
         self.into()

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,11 @@ error_chain! {
             display("HTTP Status: '{}'", s)
         }
 
+        StatusText(s: StatusCode, m: String) {
+            description("HTTP Status Code")
+            display("HTTP Status: '{}' Message: {}", s, m)
+        }
+
         Limited(s: StatusCode, t: Option<i64>) {
             description("Reached API Limits")
             display("{} Retry in: '{:?}'", s, t)

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,11 @@ error_chain! {
         UTF8(std::string::FromUtf8Error);
     }
     errors {
+        Closed(m: String) {
+            description("Connection was closed")
+            display("The connection was closed: {}", m)
+        }
+
         Status(s: StatusCode) {
             description("HTTP Status Code")
             display("HTTP Status: '{}'", s)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,8 @@ pub struct Webex {
 pub struct WebexEventStream {
     ws_stream: WStream,
     timeout: Duration,
-    is_open: bool,
+    /// Signifies if WebStream is Open
+    pub is_open: bool,
 }
 
 impl WebexEventStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,16 @@ impl Webex {
         }
     }
 
+    /// Get available room
+    pub async fn get_room(&self, id: &str) -> Result<types::Room, Error> {
+        let rest_method = format!("rooms/{}", id);
+        let room_reply: Result<types::Room, _> = self.api_get(rest_method.as_str()).await;
+        match room_reply {
+            Err(e) => Err(Error::with_chain(e, "room failed: ")),
+            Ok(rr) => Ok(rr),
+        }
+    }
+
     /// Get information about person
     pub async fn get_person(&self, id: &str) -> Result<types::Person, Error> {
         let rest_method = format!("people/{}", id);

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,7 +22,7 @@ pub struct Room {
     #[serde(rename = "isLocked")]
     pub is_locked: bool,
     /// The ID for the team with which this room is associated.
-    #[serde(rename = "teamId")]
+    #[serde(rename = "teamId", skip_serializing_if = "Option::is_none")]
     pub team_id: Option<String>,
     /// The date and time of the room's last activity.
     #[serde(rename = "lastActivity")]
@@ -45,24 +45,28 @@ pub struct RoomsReply {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct MessageOut {
     /// The parent message to reply to.
-    #[serde(rename = "parentId")]
+    #[serde(rename = "parentId", skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
     /// The room ID of the message.
-    #[serde(rename = "roomId")]
+    #[serde(rename = "roomId", skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The person ID of the recipient when sending a private 1:1 message.
-    #[serde(rename = "toPersonId")]
+    #[serde(rename = "toPersonId", skip_serializing_if = "Option::is_none")]
     pub to_person_id: Option<String>,
     /// The email address of the recipient when sending a private 1:1 message.
-    #[serde(rename = "toPersonEmail")]
+    #[serde(rename = "toPersonEmail", skip_serializing_if = "Option::is_none")]
     pub to_person_email: Option<String>,
     /// The message, in plain text. If markdown is specified this parameter may be optionally used to provide alternate text for UI clients that do not support rich text. The maximum message length is 7439 bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// The message, in Markdown format. The maximum message length is 7439 bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub markdown: Option<String>,
     /// The public URL to a binary file to be posted into the room. Only one file is allowed per message. Uploaded files are automatically converted into a format that all Webex Teams clients can render. For the supported media types and the behavior of uploads, see the [Message Attachments Guide](https://developer.webex.com/docs/api/basics#message-attachments).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<String>>,
     /// Content attachments to attach to the message. Only one card per message is supported.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<Attachment>>,
 }
 
@@ -70,45 +74,52 @@ pub struct MessageOut {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct Message {
     /// The unique identifier for the message.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// The room ID of the message.
-    #[serde(rename = "roomId")]
+    #[serde(rename = "roomId", skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The room type.
     ///
     /// direct - 1:1 room
     /// group - group room
-    #[serde(rename = "roomType")]
+    #[serde(rename = "roomType", skip_serializing_if = "Option::is_none")]
     pub room_type: Option<String>,
     /// The person ID of the recipient when sending a private 1:1 message.
-    #[serde(rename = "toPersonId")]
+    #[serde(rename = "toPersonId", skip_serializing_if = "Option::is_none")]
     pub to_person_id: Option<String>,
     /// The email address of the recipient when sending a private 1:1 message.
-    #[serde(rename = "toPersonEmail")]
+    #[serde(rename = "toPersonEmail", skip_serializing_if = "Option::is_none")]
     pub to_person_email: Option<String>,
     /// The message, in plain text. If markdown is specified this parameter may be optionally used to provide alternate text for UI clients that do not support rich text.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// The message, in Markdown format.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub markdown: Option<String>,
     /// The text content of the message, in HTML format. This read-only property is used by the Webex Teams clients.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub html: Option<String>,
     /// Public URLs for files attached to the message. For the supported media types and the behavior of file uploads, see Message Attachments.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<String>>,
     /// The person ID of the message author.
-    #[serde(rename = "personId")]
+    #[serde(rename = "personId", skip_serializing_if = "Option::is_none")]
     pub person_id: Option<String>,
     /// The email address of the message author.
-    #[serde(rename = "personEmail")]
+    #[serde(rename = "personEmail", skip_serializing_if = "Option::is_none")]
     pub person_email: Option<String>,
     /// People IDs for anyone mentioned in the message.
-    #[serde(rename = "mentionedPeople")]
+    #[serde(rename = "mentionedPeople", skip_serializing_if = "Option::is_none")]
     pub mentioned_people: Option<Vec<String>>,
     /// Group names for the groups mentioned in the message.
-    #[serde(rename = "mentionedGroups")]
+    #[serde(rename = "mentionedGroups", skip_serializing_if = "Option::is_none")]
     pub mentioned_groups: Option<Vec<String>>,
     /// Message content attachments attached to the message.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<Attachment>>,
     /// The date and time the message was created.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
 }
 
@@ -134,10 +145,13 @@ pub struct Error {
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug)]
 pub struct DevicesReply {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub devices: Option<Vec<DeviceData>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<Error>>,
-    #[serde(rename = "trackingId")]
+    #[serde(rename = "trackingId", skip_serializing_if = "Option::is_none")]
     pub tracking_id: Option<String>,
 }
 
@@ -191,8 +205,11 @@ pub struct DeviceData {
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct DeviceFeatures {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub developer: Option<Vec<DeviceFeatureData>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entitlement: Option<Vec<DeviceFeatureData>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<Vec<DeviceFeatureData>>,
 }
 
@@ -200,12 +217,17 @@ pub struct DeviceFeatures {
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct DeviceFeatureData {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub val: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mutable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_modified: Option<String>,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub type_field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted_time: Option<i64>,
 }
 
@@ -292,9 +314,11 @@ pub struct Actor {
 pub struct EventData {
     #[serde(rename = "eventType")]
     pub event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub actor: Option<Actor>,
-    #[serde(rename = "conversationId")]
+    #[serde(rename = "conversationId", skip_serializing_if = "Option::is_none")]
     pub conversation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub activity: Option<Activity>,
 }
 
@@ -309,12 +333,13 @@ pub struct Activity {
     pub verb: String,
     pub actor: Actor,
     pub object: Object,
-    pub target: Target,
-    #[serde(rename = "clientTempId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<Target>,
+    #[serde(rename = "clientTempId", skip_serializing_if = "Option::is_none")]
     pub client_temp_id: Option<String>,
-    #[serde(rename = "encryptionKeyUrl")]
+    #[serde(rename = "encryptionKeyUrl", skip_serializing_if = "Option::is_none")]
     pub encryption_key_url: Option<String>,
-    #[serde(rename = "vectorCounters")]
+    #[serde(rename = "vectorCounters", skip_serializing_if = "Option::is_none")]
     pub vector_counters: Option<VectorCounters>,
 }
 
@@ -343,10 +368,13 @@ pub struct Target {
 pub struct Object {
     #[serde(rename = "objectType")]
     pub object_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    #[serde(rename = "displayName")]
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mentions: Option<MiscItems>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub inputs: Option<String>,
 }
 
@@ -372,8 +400,8 @@ pub struct Event {
     pub timestamp: i64,
     #[serde(rename = "trackingId")]
     pub tracking_id: String,
-    #[serde(rename = "alertType")]
-    pub alert_type: String,
+    #[serde(rename = "alertType", skip_serializing_if = "Option::is_none")]
+    pub alert_type: Option<String>,
     pub headers: HashMap<String, String>,
     #[serde(rename = "sequenceNumber")]
     pub sequence_number: i64,
@@ -479,16 +507,21 @@ pub struct Action {
     /// A unique identifier for the action.
     pub id: String,
     /// The type of action performed.
-    #[serde(rename = "type")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub type_field: Option<String>,
     /// The parent message the attachment action was performed on.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
     /// The action's inputs.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub inputs: Option<HashMap<String, String>>,
     /// The ID of the person who performed the action.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub person_id: Option<String>,
     /// The ID of the room the action was performed within.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The date and time the action was created.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
 }


### PR DESCRIPTION
Namely:
Skip "None" serialization
Add Error StatusText and use it on API replies

The first one is to limit the message size from clutter.
Second one was a debug thing but came in handy because some errors from the API provide more information in the body.

Have been having some issues with AdaptiveCards so removing Height from ColumnSet(unsupported feature)