### PR TITLE
Fix for tokio dep mixup, wrong message IDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Scott Hutton <shutton@pobox.com>", "Milan Stastny <milan@stastnej.ch>"]
 edition = "2018"
 description = "Interface to Webex Teams REST and WebSocket APIs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ hyper = { version = "0.14", features = ["client", "http2"] }
 hyper-tls = "0.5"
 log = "0.4"
 serde_json = "1.0"
-tokio-tls = "0.3"
+tokio-native-tls = "0.3"
 tungstenite = "0.17"
 url = "2.2"
 

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -43,6 +43,7 @@ pub struct AdaptiveCard {
 
 impl AdaptiveCard {
     /// Create new adaptive card with mandatory defaults
+    #[must_use]
     pub fn new() -> Self {
         AdaptiveCard {
             card_type: "AdaptiveCard".to_string(),
@@ -61,7 +62,7 @@ impl AdaptiveCard {
     ///
     /// # Arguments
     ///
-    /// * `card` - CardElement to add
+    /// * `card` - `CardElement` to add
     pub fn add_body<T: Into<CardElement>>(&mut self, card: T) -> Self {
         self.body = Some(match self.body.clone() {
             None => {
@@ -480,6 +481,7 @@ impl From<&mut CardElement> for CardElement {
 /// Functions for Card Element
 impl CardElement {
     /// Create container
+    #[must_use]
     pub fn container() -> Self {
         CardElement::Container {
             items: vec![],
@@ -659,6 +661,7 @@ impl CardElement {
     }
 
     /// Create factSet
+    #[must_use]
     pub fn fact_set() -> CardElement {
         CardElement::FactSet {
             facts: vec![],
@@ -704,6 +707,7 @@ impl CardElement {
     }
 
     /// Create columnSet
+    #[must_use]
     pub fn column_set() -> CardElement {
         CardElement::ColumnSet {
             columns: vec![],
@@ -778,6 +782,7 @@ impl CardElement {
     }
 
     /// Create actionSet
+    #[must_use]
     pub fn action_set() -> CardElement {
         CardElement::ActionSet {
             actions: vec![],
@@ -794,7 +799,7 @@ impl CardElement {
     }
 }
 
-/// Defines a container that is part of a ColumnSet.
+/// Defines a container that is part of a `ColumnSet`.
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct Column {
     /// The card elements to render inside the Column.
@@ -839,6 +844,7 @@ impl From<&mut Column> for Column {
 
 impl Column {
     /// Creates new Column
+    #[must_use]
     pub fn new() -> Self {
         Column {
             items: vec![],
@@ -864,7 +870,7 @@ impl Column {
         self.into()
     }
 
-    /// Sets VerticalContentAlignment
+    /// Sets `VerticalContentAlignment`
     pub fn set_vertical_alignment(&mut self, s: VerticalContentAlignment) -> Self {
         self.vertical_content_alignment = Some(s);
         self.into()
@@ -877,7 +883,7 @@ impl Column {
     }
 }
 
-/// Describes a Fact in a FactSet as a key/value pair.
+/// Describes a Fact in a `FactSet` as a key/value pair.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Fact {
     /// The title of the fact.
@@ -1070,7 +1076,7 @@ pub enum ActionStyle {
     Destructive,
 }
 
-/// Describes a choice for use in a ChoiceSet.
+/// Describes a choice for use in a `ChoiceSet`.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Choice {
     /// Text to display.

--- a/src/types.rs
+++ b/src/types.rs
@@ -351,13 +351,7 @@ pub struct Activity {
 impl Activity {
     #[must_use]
     pub fn get_message_id(&self) -> MessageId {
-        if let Some(target) = &self.target {
-            MessageId {
-                id: target.global_id.clone(),
-            }
-        } else {
-            MessageId::new(self.id.clone())
-        }
+        MessageId::new_with_cluster(self.id.clone(), self.target.as_ref().map(Target::get_cluster))
     }
 }
 
@@ -388,6 +382,7 @@ impl MessageId {
             Ok(_) => base64::encode(format!("ciscospark://{}/MESSAGE/{}", cluster, id)),
             Err(_) => id,
         };
+        debug_assert!(String::from_utf8(base64::decode(&id).unwrap()).unwrap().split('/').nth(3).unwrap() == "MESSAGE");
         Self { id }
     }
     #[must_use]
@@ -416,6 +411,22 @@ pub struct Target {
     pub tags: Vec<String>,
     #[serde(rename = "globalId")]
     pub global_id: String,
+}
+
+#[allow(missing_docs)]
+impl Target {
+    /// Turns a `Target` into a cluster - used for message geodata
+    pub(crate) fn get_cluster(&self) -> String {
+        let target_info = String::from_utf8(
+            base64::decode(&self.global_id)
+                .expect("event.data.target.globalId should be a base64 string"),
+        )
+        .expect("decoded globalId should be a valid utf-8 string");
+        let cluster = target_info.split('/').nth(2).expect(
+            "event.data.target.globalId should be in the form ciscospark://[cluster]/[type]/[id]",
+        );
+        cluster.to_string()
+    }
 }
 
 #[allow(missing_docs)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -349,9 +349,12 @@ pub struct Activity {
 
 #[allow(missing_docs)]
 impl Activity {
+    #[must_use]
     pub fn get_message_id(&self) -> MessageId {
         if let Some(target) = &self.target {
-            MessageId { id: target.global_id.clone() }
+            MessageId {
+                id: target.global_id.clone(),
+            }
         } else {
             MessageId::new(self.id.clone())
         }
@@ -373,9 +376,11 @@ impl From<String> for MessageId {
 
 #[allow(missing_docs)]
 impl MessageId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         Self::new_with_cluster(id, None)
     }
+    #[must_use]
     pub fn new_with_cluster(id: String, cluster: Option<String>) -> Self {
         let cluster = cluster.as_deref().unwrap_or("us");
 
@@ -385,6 +390,7 @@ impl MessageId {
         };
         Self { id }
     }
+    #[must_use]
     pub fn id(&self) -> String {
         self.id.clone()
     }


### PR DESCRIPTION
`.expect`s added should never trip, this should be part of the API contract with Webex
Sorry about the clippy lints