### PR TITLE
Work on strongly typing client API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "0.9.0"
+version = "0.5.2"
 authors = ["Scott Hutton <shutton@pobox.com>", "Milan Stastny <milan@stastnej.ch>", "Abel Shields <abel@uucp.org.uk>"]
 edition = "2018"
 description = "Interface to Webex Teams REST and WebSocket APIs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "webex"
-version = "0.5.1"
-authors = ["Scott Hutton <shutton@pobox.com>", "Milan Stastny <milan@stastnej.ch>"]
+version = "1.0.0"
+authors = ["Scott Hutton <shutton@pobox.com>", "Milan Stastny <milan@stastnej.ch>", "Abel Shields <abel@uucp.org.uk>"]
 edition = "2018"
 description = "Interface to Webex Teams REST and WebSocket APIs"
 keywords = ["webex", "spark"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 tokio-native-tls = "0.3"
 tungstenite = "0.17"
 url = "2.2"
+lazy_static = "1.4.0"
 
 [dependencies.chrono]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "1.0.0"
+version = "0.9.0"
 authors = ["Scott Hutton <shutton@pobox.com>", "Milan Stastny <milan@stastnej.ch>", "Abel Shields <abel@uucp.org.uk>"]
 edition = "2018"
 description = "Interface to Webex Teams REST and WebSocket APIs"

--- a/examples/adaptivecard.rs
+++ b/examples/adaptivecard.rs
@@ -1,0 +1,162 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub(crate) struct Config {
+    pub bot_token: String,
+    //pub admins: Vec<String>,
+    pub email: String,
+}
+use std::collections::HashMap;
+
+use tokio;
+use webex::{
+    self,
+    adaptive_card::{AdaptiveCard, CardElement},
+};
+
+const HELP_MESSAGE: &str = r#"
+# Test AdaptiveCard
+Usage:
+ * `help` - show this help message
+ * `start` - show test card
+"#;
+
+#[tokio::main]
+async fn main() {
+    let config = std::fs::read_to_string("config.json").expect("Failed to find config.json");
+    let config: Config = serde_json::from_str(&config).expect("config.json invalid format");
+    let webex = webex::Webex::new(&config.bot_token).await;
+    let mut eventstream = webex
+        .event_stream()
+        .await
+        .expect("Failed to get eventstream");
+
+    while eventstream.is_open {
+        let event = match eventstream.next().await {
+            Ok(event) => event,
+            Err(e) => {
+                println!("Eventstream failed: {}", e);
+                continue;
+            }
+        };
+        match event.activity_type() {
+            webex::ActivityType::Message(webex::MessageActivity::Posted) => {
+                respond_to_message(&webex, &config, &event).await
+            }
+            webex::ActivityType::AdaptiveCardSubmit => handle_adaptive_card(&webex, &event).await,
+            _ => {
+                //dbg!(event);
+            }
+        }
+    }
+    println!("Eventstream closed!");
+}
+
+async fn handle_adaptive_card(webex: &webex::Webex, event: &webex::Event) {
+    // get attachmentactions
+    let actions: webex::types::AttachmentAction = match webex.get(&event.get_global_id()).await {
+        Ok(a) => a,
+        Err(e) => {
+            println!("Error: {}", e);
+            return;
+        }
+    };
+    let which_card = actions.inputs.as_ref().and_then(|inputs| inputs.get("id"));
+    match which_card {
+        None => println!("ERROR: expected card to have both inputs and id, got {:?}", actions),
+        Some(s) => match s.as_str() {
+            "init" => handle_adaptive_card_init(webex, &actions).await,
+            id => println!("AdaptiveCard id {id} not handled!"),
+        },
+    }
+}
+
+async fn handle_adaptive_card_init(webex: &webex::Webex, actions: &webex::AttachmentAction) {
+    // get attachmentactions
+    let input1 = actions.inputs.as_ref().and_then(|inputs| inputs.get("input1"));
+    let input2 = actions
+        .inputs
+        .as_ref()
+        .and_then(|inputs| inputs.get("input2"));
+    match (input1, input2) {
+        (Some(input1), Some(input2)) => {
+            println!("Recieved initial adaptive card, inputs {} and {}", input1, input2);
+            return;
+        }
+        _ => {}
+    }
+    let mut reply = webex::MessageOut::from(actions);
+    reply.text = Some(format!(
+        "Your replies were: {:?}",
+        actions.inputs.as_ref().expect("expected action to have inputs")
+    ));
+    webex
+        .send_message(&reply)
+        .await
+        .expect("Couldn't send reply");
+}
+
+async fn respond_to_message(webex: &webex::Webex, config: &Config, event: &webex::Event) {
+    // Got a posted message
+    let message: webex::Message = match webex.get(&event.get_global_id()).await {
+        Ok(msg) => msg,
+        Err(e) => {
+            println!("Failed to get message: {}", e);
+            return;
+        }
+    };
+    if message.person_email.as_ref() == Some(&config.email) {
+        return;
+    }
+
+    let mut reply: webex::MessageOut = webex::MessageOut::from(&message);
+    if message
+        .text
+        .as_ref()
+        .map(|msg| msg.contains("help"))
+        .unwrap_or(false)
+    {
+        // Send help message
+        reply.markdown = Some(HELP_MESSAGE.into());
+        webex
+            .send_message(&reply)
+            .await
+            .expect("Failed to send help message");
+        return;
+    }
+
+    // Send event card
+    reply.text = Some("Welcome to Adaptivecard Tester Bot".into());
+    let mut body = CardElement::container();
+    body.add_element(CardElement::text_block("Welcome to Adaptivecard Tester Bot!"));
+    body.add_element(
+        CardElement::column_set()
+            .add_column(
+                webex::adaptive_card::Column::new()
+                    .add_element(CardElement::text_block("Input 1:"))
+                    .add_element(CardElement::text_block("Input 2:")),
+            )
+            .add_column(
+                webex::adaptive_card::Column::new()
+                    .add_element(
+                        CardElement::input_choice_set("input1", None::<&'static str>)
+                            .add_key_value("Option A", "First Option")
+                            .add_key_value("Option B", "Second Option"),
+                    )
+                    .add_element(CardElement::input_text("input2", None::<&'static str>)),
+            ),
+    );
+    body.add_element(CardElement::action_set().add_action_to_set(
+        webex::adaptive_card::Action::Submit {
+            data: Some(HashMap::from([("id".into(), "init".into())])),
+            title: Some("Submit".into()),
+            style: None,
+        },
+    ));
+    let card = AdaptiveCard::new().add_body(body);
+    reply.add_attachment(card);
+    let _resp = webex
+        .send_message(&reply)
+        .await
+        .expect("Failed to send message");
+}

--- a/examples/adaptivecard.rs
+++ b/examples/adaptivecard.rs
@@ -8,7 +8,7 @@ pub(crate) struct Config {
 }
 use std::collections::HashMap;
 
-use tokio;
+
 use webex::{
     self,
     adaptive_card::{AdaptiveCard, CardElement},
@@ -78,13 +78,11 @@ async fn handle_adaptive_card_init(webex: &webex::Webex, actions: &webex::Attach
         .inputs
         .as_ref()
         .and_then(|inputs| inputs.get("input2"));
-    match (input1, input2) {
-        (Some(input1), Some(input2)) => {
-            println!("Recieved initial adaptive card, inputs {} and {}", input1, input2);
-            return;
-        }
-        _ => {}
+    if let (Some(input1), Some(input2)) = (input1, input2) {
+        println!("Recieved initial adaptive card, inputs {} and {}", input1, input2);
+        return;
     }
+
     let mut reply = webex::MessageOut::from(actions);
     reply.text = Some(format!(
         "Your replies were: {:?}",

--- a/examples/adaptivecard.rs
+++ b/examples/adaptivecard.rs
@@ -8,7 +8,6 @@ pub(crate) struct Config {
 }
 use std::collections::HashMap;
 
-
 use webex::{
     self,
     adaptive_card::{AdaptiveCard, CardElement},
@@ -63,7 +62,10 @@ async fn handle_adaptive_card(webex: &webex::Webex, event: &webex::Event) {
     };
     let which_card = actions.inputs.as_ref().and_then(|inputs| inputs.get("id"));
     match which_card {
-        None => println!("ERROR: expected card to have both inputs and id, got {:?}", actions),
+        None => println!(
+            "ERROR: expected card to have both inputs and id, got {:?}",
+            actions
+        ),
         Some(s) => match s.as_str() {
             "init" => handle_adaptive_card_init(webex, &actions).await,
             id => println!("AdaptiveCard id {id} not handled!"),
@@ -73,20 +75,29 @@ async fn handle_adaptive_card(webex: &webex::Webex, event: &webex::Event) {
 
 async fn handle_adaptive_card_init(webex: &webex::Webex, actions: &webex::AttachmentAction) {
     // get attachmentactions
-    let input1 = actions.inputs.as_ref().and_then(|inputs| inputs.get("input1"));
+    let input1 = actions
+        .inputs
+        .as_ref()
+        .and_then(|inputs| inputs.get("input1"));
     let input2 = actions
         .inputs
         .as_ref()
         .and_then(|inputs| inputs.get("input2"));
     if let (Some(input1), Some(input2)) = (input1, input2) {
-        println!("Recieved initial adaptive card, inputs {} and {}", input1, input2);
+        println!(
+            "Recieved initial adaptive card, inputs {} and {}",
+            input1, input2
+        );
         return;
     }
 
     let mut reply = webex::MessageOut::from(actions);
     reply.text = Some(format!(
         "Your replies were: {:?}",
-        actions.inputs.as_ref().expect("expected action to have inputs")
+        actions
+            .inputs
+            .as_ref()
+            .expect("expected action to have inputs")
     ));
     webex
         .send_message(&reply)
@@ -126,7 +137,9 @@ async fn respond_to_message(webex: &webex::Webex, config: &Config, event: &webex
     // Send event card
     reply.text = Some("Welcome to Adaptivecard Tester Bot".into());
     let mut body = CardElement::container();
-    body.add_element(CardElement::text_block("Welcome to Adaptivecard Tester Bot!"));
+    body.add_element(CardElement::text_block(
+        "Welcome to Adaptivecard Tester Bot!",
+    ));
     body.add_element(
         CardElement::column_set()
             .add_column(

--- a/examples/auto-reply.rs
+++ b/examples/auto-reply.rs
@@ -39,7 +39,7 @@ async fn main() {
             if let Some(activity) = &event.data.activity {
                 if activity.verb.as_str() == "post" {
                     // The event stream doesn't contain the message -- you have to go fetch it
-                    if let Ok(msg) = webex.get_message(activity.id.as_str()).await {
+                    if let Ok(msg) = webex.get_message(&event.get_global_id().expect("Get event global id")).await {
                         match &msg.person_email {
                             // Reply as long as it doesn't appear to be our own message
                             // In practice, this shouldn't happen since bots can't see messages

--- a/examples/auto-reply.rs
+++ b/examples/auto-reply.rs
@@ -30,17 +30,14 @@ async fn main() {
     let bot_email = env::var(BOT_EMAIL)
         .unwrap_or_else(|_| panic!("{} not specified in environment", BOT_EMAIL));
 
-    let webex = webex::Webex::new(token.as_str());
+    let webex = webex::Webex::new(token.as_str()).await;
     let mut event_stream = webex.event_stream().await.expect("event stream");
 
     while let Ok(event) = event_stream.next().await {
         // Dig out the useful bit
         if event.activity_type() == webex::ActivityType::Message(webex::MessageActivity::Posted) {
             // The event stream doesn't contain the message -- you have to go fetch it
-            if let Ok(msg) = webex
-                .get_message(&event.get_global_id().expect("Get event global id"))
-                .await
-            {
+            if let Ok(msg) = webex.get::<webex::Message>(&event.get_global_id()).await {
                 match &msg.person_email {
                     // Reply as long as it doesn't appear to be our own message
                     // In practice, this shouldn't happen since bots can't see messages

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -28,7 +28,7 @@ async fn main() {
     let to_email = env::var(DEST_EMAIL)
         .unwrap_or_else(|_| panic!("{} not specified in environment", DEST_EMAIL));
 
-    let webex = webex::Webex::new(token.as_str());
+    let webex = webex::Webex::new(token.as_str()).await;
     let text = format!("Hello, {}", to_email);
 
     let msg_to_send = webex::types::MessageOut {

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -848,28 +848,24 @@ impl Column {
     }
 
     /// Adds element to column
-    #[must_use]
     pub fn add_element(&mut self, item: CardElement) -> Self {
         self.items.push(item);
         self.into()
     }
 
     /// Sets separator
-    #[must_use]
     pub fn set_separator(&mut self, s: bool) -> Self {
         self.separator = Some(s);
         self.into()
     }
 
     /// Sets `VerticalContentAlignment`
-    #[must_use]
     pub fn set_vertical_alignment(&mut self, s: VerticalContentAlignment) -> Self {
         self.vertical_content_alignment = Some(s);
         self.into()
     }
 
     /// Sets width
-    #[must_use]
     pub fn set_width<T: Into<String>>(&mut self, s: T) -> Self {
         self.width = Some(s.into());
         self.into()

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -518,6 +518,15 @@ impl CardElement {
         }
         self.into()
     }
+
+    /// Set container contents vertical alignment
+    pub fn set_container_vertical_alignment(&mut self, align: VerticalContentAlignment) -> Self {
+        if let Self::Container { vertical_content_alignment, .. } = self {
+            *vertical_content_alignment = Some(align);
+        }
+        self.into()
+    }
+
     /// Create input.Text
     #[must_use]
     pub fn input_text<T: Into<String>, S: Into<String>>(id: T, value: Option<S>) -> Self {

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -775,9 +775,9 @@ impl CardElement {
     /// Set Placeholder
     pub fn set_placeholder(&mut self, s: Option<String>) -> Self {
         match self {
-            CardElement::InputText { placeholder, .. } |
-            CardElement::InputNumber { placeholder, .. } |
-            CardElement::InputDate { placeholder, .. } => {
+            CardElement::InputText { placeholder, .. }
+            | CardElement::InputNumber { placeholder, .. }
+            | CardElement::InputDate { placeholder, .. } => {
                 *placeholder = s;
             }
             _ => {

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -65,6 +65,9 @@ impl AdaptiveCard {
     ///
     /// * `card` - `CardElement` to add
     pub fn add_body<T: Into<CardElement>>(&mut self, card: T) -> Self {
+        //self.body = self.body.map_or_else(|| Some(vec![card.into()]), |body| body.push(card.into()));
+        //self.body = Some(self.body.unwrap_or_default().push(card.into()));
+        // TODO: improve this - can we use take()?
         self.body = Some(match self.body.clone() {
             None => {
                 vec![card.into()]

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![allow(clippy::return_self_not_must_use)]
 //! Adaptive Card implementation
 //!
 //! [Webex Teams currently supports only version 1.1](https://developer.webex.com/docs/cards)
@@ -63,7 +64,6 @@ impl AdaptiveCard {
     /// # Arguments
     ///
     /// * `card` - `CardElement` to add
-    #[must_use]
     pub fn add_body<T: Into<CardElement>>(&mut self, card: T) -> Self {
         self.body = Some(match self.body.clone() {
             None => {
@@ -82,7 +82,6 @@ impl AdaptiveCard {
     /// # Arguments
     ///
     /// * `action` - Action to add
-    #[must_use]
     pub fn add_action<T: Into<Action>>(&mut self, a: T) -> Self {
         self.actions = Some(match self.actions.clone() {
             None => {
@@ -471,12 +470,14 @@ pub enum CardElement {
 }
 
 impl From<&CardElement> for CardElement {
+    #[must_use]
     fn from(item: &CardElement) -> Self {
         item.clone()
     }
 }
 
 impl From<&mut CardElement> for CardElement {
+    #[must_use]
     fn from(item: &mut CardElement) -> Self {
         item.clone()
     }
@@ -500,7 +501,6 @@ impl CardElement {
     }
 
     /// Add element to Container
-    #[must_use]
     pub fn add_element<T: Into<CardElement>>(&mut self, element: T) -> Self {
         if let CardElement::Container { items, .. } = self {
             items.push(element.into());
@@ -509,7 +509,6 @@ impl CardElement {
     }
 
     /// Set Container Style
-    #[must_use]
     pub fn set_container_style(&mut self, s: ContainerStyle) -> Self {
         if let CardElement::Container { style, .. } = self {
             *style = Some(s);
@@ -534,7 +533,6 @@ impl CardElement {
     }
 
     /// Set Text Input Multiline
-    #[must_use]
     pub fn set_multiline(&mut self, s: bool) -> Self {
         if let CardElement::InputText { is_multiline, .. } = self {
             *is_multiline = Some(s);
@@ -573,7 +571,6 @@ impl CardElement {
     }
 
     /// Set choiceSet Style
-    #[must_use]
     pub fn set_style(&mut self, s: ChoiceInputStyle) -> Self {
         if let CardElement::InputChoiceSet { style, .. } = self {
             *style = Some(s);
@@ -582,7 +579,6 @@ impl CardElement {
     }
 
     /// Set title Style
-    #[must_use]
     pub fn set_title(&mut self, s: String) -> Self {
         if let CardElement::InputToggle { title, .. } = self {
             *title = Some(s);
@@ -591,7 +587,6 @@ impl CardElement {
     }
 
     /// Set choiceSet Style
-    #[must_use]
     pub fn set_multiselect(&mut self, b: bool) -> Self {
         if let CardElement::InputChoiceSet {
             is_multi_select, ..
@@ -627,7 +622,6 @@ impl CardElement {
     }
 
     /// Set Text Weight
-    #[must_use]
     pub fn set_weight(&mut self, w: Weight) -> Self {
         if let CardElement::TextBlock { weight, .. } = self {
             *weight = Some(w);
@@ -636,7 +630,6 @@ impl CardElement {
     }
 
     /// Set Text Font Type
-    #[must_use]
     pub fn set_font(&mut self, f: FontType) -> Self {
         if let CardElement::TextBlock { font_type, .. } = self {
             *font_type = Some(f);
@@ -645,7 +638,6 @@ impl CardElement {
     }
 
     /// Set Text Size
-    #[must_use]
     pub fn set_size(&mut self, s: Size) -> Self {
         if let CardElement::TextBlock { size, .. } = self {
             *size = Some(s);
@@ -654,7 +646,6 @@ impl CardElement {
     }
 
     /// Set Text Color
-    #[must_use]
     pub fn set_color(&mut self, c: Color) -> Self {
         if let CardElement::TextBlock { color, .. } = self {
             *color = Some(c);
@@ -663,7 +654,6 @@ impl CardElement {
     }
 
     /// Set Text wrap
-    #[must_use]
     pub fn set_wrap(&mut self, w: bool) -> Self {
         if let CardElement::TextBlock { wrap, .. } = self {
             *wrap = Some(w);
@@ -672,7 +662,6 @@ impl CardElement {
     }
 
     /// Set Text subtle
-    #[must_use]
     pub fn set_subtle(&mut self, s: bool) -> Self {
         if let CardElement::TextBlock { is_subtle, .. } = self {
             *is_subtle = Some(s);
@@ -711,7 +700,6 @@ impl CardElement {
     }
 
     /// Add fact to factSet
-    #[must_use]
     pub fn add_key_value<T: Into<String>, S: Into<String>>(&mut self, title: T, value: S) -> Self {
         match self {
             CardElement::FactSet { facts, .. } => facts.push(Fact {
@@ -740,7 +728,6 @@ impl CardElement {
     }
 
     /// Add column to columnSet
-    #[must_use]
     pub fn add_column(&mut self, column: Column) -> Self {
         if let CardElement::ColumnSet { columns, .. } = self {
             columns.push(column);
@@ -749,7 +736,6 @@ impl CardElement {
     }
 
     /// Set Separator
-    #[must_use]
     pub fn set_separator(&mut self, s: bool) -> Self {
         match self {
             CardElement::TextBlock { separator, .. }
@@ -767,7 +753,6 @@ impl CardElement {
     }
 
     /// Set Spacing
-    #[must_use]
     pub fn set_spacing(&mut self, s: Spacing) -> Self {
         match self {
             CardElement::TextBlock { spacing, .. }
@@ -793,7 +778,6 @@ impl CardElement {
     }
 
     /// Add action to actionSet
-    #[must_use]
     pub fn add_action_to_set(&mut self, action: Action) -> Self {
         if let CardElement::ActionSet { actions, .. } = self {
             actions.push(action);

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -36,7 +36,7 @@ pub struct AdaptiveCard {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lang: Option<String>,
     /// The Adaptive Card schema.
-    /// http://adaptivecards.io/schemas/adaptive-card.json
+    /// <http://adaptivecards.io/schemas/adaptive-card.json>
     #[serde(rename = "$schema")]
     pub schema: String,
 }

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -727,7 +727,7 @@ impl CardElement {
                 value: value.into(),
             }),
             _ => {
-                log::warn!("Card does not have key value type field")
+                log::warn!("Card does not have key value type field");
             }
         }
         self.into()
@@ -766,7 +766,7 @@ impl CardElement {
                 *separator = Some(s);
             }
             _ => {
-                log::warn!("Card does not have separator field")
+                log::warn!("Card does not have separator field");
             }
         }
         self.into()
@@ -775,17 +775,13 @@ impl CardElement {
     /// Set Placeholder
     pub fn set_placeholder(&mut self, s: Option<String>) -> Self {
         match self {
-            CardElement::InputText { placeholder, .. } => {
-                *placeholder = s;
-            }
-            CardElement::InputNumber { placeholder, .. } => {
-                *placeholder = s;
-            }
+            CardElement::InputText { placeholder, .. } |
+            CardElement::InputNumber { placeholder, .. } |
             CardElement::InputDate { placeholder, .. } => {
                 *placeholder = s;
             }
             _ => {
-                log::warn!("Card does not have placeholder field")
+                log::warn!("Card does not have placeholder field");
             }
         }
         self.into()
@@ -803,7 +799,7 @@ impl CardElement {
                 *spacing = Some(s);
             }
             _ => {
-                log::warn!("Card does not have spacing field")
+                log::warn!("Card does not have spacing field");
             }
         }
         self.into()

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -520,7 +520,7 @@ impl CardElement {
     }
 
     /// Set container contents vertical alignment
-    pub fn set_container_vertical_alignment(&mut self, align: VerticalContentAlignment) -> Self {
+    pub fn set_vertical_alignment(&mut self, align: VerticalContentAlignment) -> Self {
         if let Self::Container { vertical_content_alignment, .. } = self {
             *vertical_content_alignment = Some(align);
         }

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -521,7 +521,11 @@ impl CardElement {
 
     /// Set container contents vertical alignment
     pub fn set_vertical_alignment(&mut self, align: VerticalContentAlignment) -> Self {
-        if let Self::Container { vertical_content_alignment, .. } = self {
+        if let Self::Container {
+            vertical_content_alignment,
+            ..
+        } = self
+        {
             *vertical_content_alignment = Some(align);
         }
         self.into()
@@ -613,7 +617,7 @@ impl CardElement {
     ///
     /// # Arguments
     ///
-    /// * `text` - Text to set to the new text block(Must implement Into<String>
+    /// * `text` - Text to set to the new text block (Must implement `Into<String>`)
     #[must_use]
     pub fn text_block<T: Into<String>>(text: T) -> Self {
         Self::TextBlock {

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -46,7 +46,7 @@ impl AdaptiveCard {
     /// Create new adaptive card with mandatory defaults
     #[must_use]
     pub fn new() -> Self {
-        AdaptiveCard {
+        Self {
             card_type: "AdaptiveCard".to_string(),
             version: "1.1".to_string(),
             body: None,
@@ -96,16 +96,16 @@ impl AdaptiveCard {
     }
 }
 
-impl From<&AdaptiveCard> for AdaptiveCard {
+impl From<&Self> for AdaptiveCard {
     #[must_use]
-    fn from(item: &AdaptiveCard) -> Self {
+    fn from(item: &Self) -> Self {
         item.clone()
     }
 }
 
-impl From<&mut AdaptiveCard> for AdaptiveCard {
+impl From<&mut Self> for AdaptiveCard {
     #[must_use]
-    fn from(item: &mut AdaptiveCard) -> Self {
+    fn from(item: &mut Self) -> Self {
         item.clone()
     }
 }
@@ -469,16 +469,16 @@ pub enum CardElement {
     },
 }
 
-impl From<&CardElement> for CardElement {
+impl From<&Self> for CardElement {
     #[must_use]
-    fn from(item: &CardElement) -> Self {
+    fn from(item: &Self) -> Self {
         item.clone()
     }
 }
 
-impl From<&mut CardElement> for CardElement {
+impl From<&mut Self> for CardElement {
     #[must_use]
-    fn from(item: &mut CardElement) -> Self {
+    fn from(item: &mut Self) -> Self {
         item.clone()
     }
 }
@@ -487,8 +487,8 @@ impl From<&mut CardElement> for CardElement {
 impl CardElement {
     /// Create container
     #[must_use]
-    pub fn container() -> Self {
-        CardElement::Container {
+    pub const fn container() -> Self {
+        Self::Container {
             items: vec![],
             select_action: None,
             style: None,
@@ -501,8 +501,8 @@ impl CardElement {
     }
 
     /// Add element to Container
-    pub fn add_element<T: Into<CardElement>>(&mut self, element: T) -> Self {
-        if let CardElement::Container { items, .. } = self {
+    pub fn add_element<T: Into<Self>>(&mut self, element: T) -> Self {
+        if let Self::Container { items, .. } = self {
             items.push(element.into());
         }
         self.into()
@@ -510,7 +510,7 @@ impl CardElement {
 
     /// Set Container Style
     pub fn set_container_style(&mut self, s: ContainerStyle) -> Self {
-        if let CardElement::Container { style, .. } = self {
+        if let Self::Container { style, .. } = self {
             *style = Some(s);
         }
         self.into()
@@ -518,7 +518,7 @@ impl CardElement {
     /// Create input.Text
     #[must_use]
     pub fn input_text<T: Into<String>, S: Into<String>>(id: T, value: Option<S>) -> Self {
-        CardElement::InputText {
+        Self::InputText {
             id: id.into(),
             placeholder: None,
             is_multiline: None,
@@ -534,7 +534,7 @@ impl CardElement {
 
     /// Set Text Input Multiline
     pub fn set_multiline(&mut self, s: bool) -> Self {
-        if let CardElement::InputText { is_multiline, .. } = self {
+        if let Self::InputText { is_multiline, .. } = self {
             *is_multiline = Some(s);
         }
         self.into()
@@ -543,7 +543,7 @@ impl CardElement {
     /// Create input.ChoiceSet
     #[must_use]
     pub fn input_choice_set<T: Into<String>, S: Into<String>>(id: T, value: Option<S>) -> Self {
-        CardElement::InputChoiceSet {
+        Self::InputChoiceSet {
             choices: vec![],
             id: id.into(),
             is_multi_select: None,
@@ -558,7 +558,7 @@ impl CardElement {
     /// Create input.Toggle
     #[must_use]
     pub fn input_toggle<T: Into<String>>(id: T, value: bool) -> Self {
-        CardElement::InputToggle {
+        Self::InputToggle {
             id: id.into(),
             value: Some(value.to_string()),
             value_off: None,
@@ -572,7 +572,7 @@ impl CardElement {
 
     /// Set choiceSet Style
     pub fn set_style(&mut self, s: ChoiceInputStyle) -> Self {
-        if let CardElement::InputChoiceSet { style, .. } = self {
+        if let Self::InputChoiceSet { style, .. } = self {
             *style = Some(s);
         }
         self.into()
@@ -580,7 +580,7 @@ impl CardElement {
 
     /// Set title Style
     pub fn set_title(&mut self, s: String) -> Self {
-        if let CardElement::InputToggle { title, .. } = self {
+        if let Self::InputToggle { title, .. } = self {
             *title = Some(s);
         }
         self.into()
@@ -588,7 +588,7 @@ impl CardElement {
 
     /// Set choiceSet Style
     pub fn set_multiselect(&mut self, b: bool) -> Self {
-        if let CardElement::InputChoiceSet {
+        if let Self::InputChoiceSet {
             is_multi_select, ..
         } = self
         {
@@ -604,7 +604,7 @@ impl CardElement {
     /// * `text` - Text to set to the new text block(Must implement Into<String>
     #[must_use]
     pub fn text_block<T: Into<String>>(text: T) -> Self {
-        CardElement::TextBlock {
+        Self::TextBlock {
             text: text.into(),
             wrap: None,
             color: None,
@@ -623,7 +623,7 @@ impl CardElement {
 
     /// Set Text Weight
     pub fn set_weight(&mut self, w: Weight) -> Self {
-        if let CardElement::TextBlock { weight, .. } = self {
+        if let Self::TextBlock { weight, .. } = self {
             *weight = Some(w);
         }
         self.into()
@@ -631,7 +631,7 @@ impl CardElement {
 
     /// Set Text Font Type
     pub fn set_font(&mut self, f: FontType) -> Self {
-        if let CardElement::TextBlock { font_type, .. } = self {
+        if let Self::TextBlock { font_type, .. } = self {
             *font_type = Some(f);
         }
         self.into()
@@ -639,7 +639,7 @@ impl CardElement {
 
     /// Set Text Size
     pub fn set_size(&mut self, s: Size) -> Self {
-        if let CardElement::TextBlock { size, .. } = self {
+        if let Self::TextBlock { size, .. } = self {
             *size = Some(s);
         }
         self.into()
@@ -647,7 +647,7 @@ impl CardElement {
 
     /// Set Text Color
     pub fn set_color(&mut self, c: Color) -> Self {
-        if let CardElement::TextBlock { color, .. } = self {
+        if let Self::TextBlock { color, .. } = self {
             *color = Some(c);
         }
         self.into()
@@ -655,7 +655,7 @@ impl CardElement {
 
     /// Set Text wrap
     pub fn set_wrap(&mut self, w: bool) -> Self {
-        if let CardElement::TextBlock { wrap, .. } = self {
+        if let Self::TextBlock { wrap, .. } = self {
             *wrap = Some(w);
         }
         self.into()
@@ -663,7 +663,7 @@ impl CardElement {
 
     /// Set Text subtle
     pub fn set_subtle(&mut self, s: bool) -> Self {
-        if let CardElement::TextBlock { is_subtle, .. } = self {
+        if let Self::TextBlock { is_subtle, .. } = self {
             *is_subtle = Some(s);
         }
         self.into()
@@ -671,8 +671,8 @@ impl CardElement {
 
     /// Create factSet
     #[must_use]
-    pub fn fact_set() -> CardElement {
-        CardElement::FactSet {
+    pub const fn fact_set() -> Self {
+        Self::FactSet {
             facts: vec![],
             height: None,
             id: None,
@@ -682,8 +682,8 @@ impl CardElement {
     }
 
     /// Create image
-    pub fn image<T: Into<String>>(url: T) -> CardElement {
-        CardElement::Image {
+    pub fn image<T: Into<String>>(url: T) -> Self {
+        Self::Image {
             url: url.into(),
             alt_text: None,
             background_color: None,
@@ -702,11 +702,11 @@ impl CardElement {
     /// Add fact to factSet
     pub fn add_key_value<T: Into<String>, S: Into<String>>(&mut self, title: T, value: S) -> Self {
         match self {
-            CardElement::FactSet { facts, .. } => facts.push(Fact {
+            Self::FactSet { facts, .. } => facts.push(Fact {
                 title: title.into(),
                 value: value.into(),
             }),
-            CardElement::InputChoiceSet { choices, .. } => choices.push(Choice {
+            Self::InputChoiceSet { choices, .. } => choices.push(Choice {
                 title: title.into(),
                 value: value.into(),
             }),
@@ -717,8 +717,8 @@ impl CardElement {
 
     /// Create columnSet
     #[must_use]
-    pub fn column_set() -> CardElement {
-        CardElement::ColumnSet {
+    pub const fn column_set() -> Self {
+        Self::ColumnSet {
             columns: vec![],
             select_action: None,
             id: None,
@@ -729,7 +729,7 @@ impl CardElement {
 
     /// Add column to columnSet
     pub fn add_column(&mut self, column: Column) -> Self {
-        if let CardElement::ColumnSet { columns, .. } = self {
+        if let Self::ColumnSet { columns, .. } = self {
             columns.push(column);
         }
         self.into()
@@ -738,13 +738,13 @@ impl CardElement {
     /// Set Separator
     pub fn set_separator(&mut self, s: bool) -> Self {
         match self {
-            CardElement::TextBlock { separator, .. }
-            | CardElement::FactSet { separator, .. }
-            | CardElement::ColumnSet { separator, .. }
-            | CardElement::Image { separator, .. }
-            | CardElement::InputChoiceSet { separator, .. }
-            | CardElement::InputText { separator, .. }
-            | CardElement::InputToggle { separator, .. } => {
+            Self::TextBlock { separator, .. }
+            | Self::FactSet { separator, .. }
+            | Self::ColumnSet { separator, .. }
+            | Self::Image { separator, .. }
+            | Self::InputChoiceSet { separator, .. }
+            | Self::InputText { separator, .. }
+            | Self::InputToggle { separator, .. } => {
                 *separator = Some(s);
             }
             _ => {}
@@ -755,12 +755,12 @@ impl CardElement {
     /// Set Spacing
     pub fn set_spacing(&mut self, s: Spacing) -> Self {
         match self {
-            CardElement::TextBlock { spacing, .. }
-            | CardElement::FactSet { spacing, .. }
-            | CardElement::ColumnSet { spacing, .. }
-            | CardElement::Image { spacing, .. }
-            | CardElement::InputChoiceSet { spacing, .. }
-            | CardElement::InputText { spacing, .. } => {
+            Self::TextBlock { spacing, .. }
+            | Self::FactSet { spacing, .. }
+            | Self::ColumnSet { spacing, .. }
+            | Self::Image { spacing, .. }
+            | Self::InputChoiceSet { spacing, .. }
+            | Self::InputText { spacing, .. } => {
                 *spacing = Some(s);
             }
             _ => {}
@@ -770,8 +770,8 @@ impl CardElement {
 
     /// Create actionSet
     #[must_use]
-    pub fn action_set() -> CardElement {
-        CardElement::ActionSet {
+    pub const fn action_set() -> Self {
+        Self::ActionSet {
             actions: vec![],
             height: None,
         }
@@ -779,7 +779,7 @@ impl CardElement {
 
     /// Add action to actionSet
     pub fn add_action_to_set(&mut self, action: Action) -> Self {
-        if let CardElement::ActionSet { actions, .. } = self {
+        if let Self::ActionSet { actions, .. } = self {
             actions.push(action);
         }
         self.into()
@@ -817,16 +817,16 @@ pub struct Column {
     id: Option<String>,
 }
 
-impl From<&Column> for Column {
+impl From<&Self> for Column {
     #[must_use]
-    fn from(item: &Column) -> Self {
+    fn from(item: &Self) -> Self {
         item.clone()
     }
 }
 
-impl From<&mut Column> for Column {
+impl From<&mut Self> for Column {
     #[must_use]
-    fn from(item: &mut Column) -> Self {
+    fn from(item: &mut Self) -> Self {
         item.clone()
     }
 }
@@ -834,8 +834,8 @@ impl From<&mut Column> for Column {
 impl Column {
     /// Creates new Column
     #[must_use]
-    pub fn new() -> Self {
-        Column {
+    pub const fn new() -> Self {
+        Self {
             items: vec![],
             select_action: None,
             style: None,

--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -63,6 +63,7 @@ impl AdaptiveCard {
     /// # Arguments
     ///
     /// * `card` - `CardElement` to add
+    #[must_use]
     pub fn add_body<T: Into<CardElement>>(&mut self, card: T) -> Self {
         self.body = Some(match self.body.clone() {
             None => {
@@ -81,6 +82,7 @@ impl AdaptiveCard {
     /// # Arguments
     ///
     /// * `action` - Action to add
+    #[must_use]
     pub fn add_action<T: Into<Action>>(&mut self, a: T) -> Self {
         self.actions = Some(match self.actions.clone() {
             None => {
@@ -96,12 +98,14 @@ impl AdaptiveCard {
 }
 
 impl From<&AdaptiveCard> for AdaptiveCard {
+    #[must_use]
     fn from(item: &AdaptiveCard) -> Self {
         item.clone()
     }
 }
 
 impl From<&mut AdaptiveCard> for AdaptiveCard {
+    #[must_use]
     fn from(item: &mut AdaptiveCard) -> Self {
         item.clone()
     }
@@ -496,14 +500,16 @@ impl CardElement {
     }
 
     /// Add element to Container
+    #[must_use]
     pub fn add_element<T: Into<CardElement>>(&mut self, element: T) -> Self {
         if let CardElement::Container { items, .. } = self {
-            items.push(element.into())
+            items.push(element.into());
         }
         self.into()
     }
 
     /// Set Container Style
+    #[must_use]
     pub fn set_container_style(&mut self, s: ContainerStyle) -> Self {
         if let CardElement::Container { style, .. } = self {
             *style = Some(s);
@@ -511,6 +517,7 @@ impl CardElement {
         self.into()
     }
     /// Create input.Text
+    #[must_use]
     pub fn input_text<T: Into<String>, S: Into<String>>(id: T, value: Option<S>) -> Self {
         CardElement::InputText {
             id: id.into(),
@@ -527,6 +534,7 @@ impl CardElement {
     }
 
     /// Set Text Input Multiline
+    #[must_use]
     pub fn set_multiline(&mut self, s: bool) -> Self {
         if let CardElement::InputText { is_multiline, .. } = self {
             *is_multiline = Some(s);
@@ -535,6 +543,7 @@ impl CardElement {
     }
 
     /// Create input.ChoiceSet
+    #[must_use]
     pub fn input_choice_set<T: Into<String>, S: Into<String>>(id: T, value: Option<S>) -> Self {
         CardElement::InputChoiceSet {
             choices: vec![],
@@ -549,6 +558,7 @@ impl CardElement {
     }
 
     /// Create input.Toggle
+    #[must_use]
     pub fn input_toggle<T: Into<String>>(id: T, value: bool) -> Self {
         CardElement::InputToggle {
             id: id.into(),
@@ -563,6 +573,7 @@ impl CardElement {
     }
 
     /// Set choiceSet Style
+    #[must_use]
     pub fn set_style(&mut self, s: ChoiceInputStyle) -> Self {
         if let CardElement::InputChoiceSet { style, .. } = self {
             *style = Some(s);
@@ -571,6 +582,7 @@ impl CardElement {
     }
 
     /// Set title Style
+    #[must_use]
     pub fn set_title(&mut self, s: String) -> Self {
         if let CardElement::InputToggle { title, .. } = self {
             *title = Some(s);
@@ -579,6 +591,7 @@ impl CardElement {
     }
 
     /// Set choiceSet Style
+    #[must_use]
     pub fn set_multiselect(&mut self, b: bool) -> Self {
         if let CardElement::InputChoiceSet {
             is_multi_select, ..
@@ -594,6 +607,7 @@ impl CardElement {
     /// # Arguments
     ///
     /// * `text` - Text to set to the new text block(Must implement Into<String>
+    #[must_use]
     pub fn text_block<T: Into<String>>(text: T) -> Self {
         CardElement::TextBlock {
             text: text.into(),
@@ -613,6 +627,7 @@ impl CardElement {
     }
 
     /// Set Text Weight
+    #[must_use]
     pub fn set_weight(&mut self, w: Weight) -> Self {
         if let CardElement::TextBlock { weight, .. } = self {
             *weight = Some(w);
@@ -621,6 +636,7 @@ impl CardElement {
     }
 
     /// Set Text Font Type
+    #[must_use]
     pub fn set_font(&mut self, f: FontType) -> Self {
         if let CardElement::TextBlock { font_type, .. } = self {
             *font_type = Some(f);
@@ -629,6 +645,7 @@ impl CardElement {
     }
 
     /// Set Text Size
+    #[must_use]
     pub fn set_size(&mut self, s: Size) -> Self {
         if let CardElement::TextBlock { size, .. } = self {
             *size = Some(s);
@@ -637,6 +654,7 @@ impl CardElement {
     }
 
     /// Set Text Color
+    #[must_use]
     pub fn set_color(&mut self, c: Color) -> Self {
         if let CardElement::TextBlock { color, .. } = self {
             *color = Some(c);
@@ -645,6 +663,7 @@ impl CardElement {
     }
 
     /// Set Text wrap
+    #[must_use]
     pub fn set_wrap(&mut self, w: bool) -> Self {
         if let CardElement::TextBlock { wrap, .. } = self {
             *wrap = Some(w);
@@ -653,6 +672,7 @@ impl CardElement {
     }
 
     /// Set Text subtle
+    #[must_use]
     pub fn set_subtle(&mut self, s: bool) -> Self {
         if let CardElement::TextBlock { is_subtle, .. } = self {
             *is_subtle = Some(s);
@@ -691,6 +711,7 @@ impl CardElement {
     }
 
     /// Add fact to factSet
+    #[must_use]
     pub fn add_key_value<T: Into<String>, S: Into<String>>(&mut self, title: T, value: S) -> Self {
         match self {
             CardElement::FactSet { facts, .. } => facts.push(Fact {
@@ -719,6 +740,7 @@ impl CardElement {
     }
 
     /// Add column to columnSet
+    #[must_use]
     pub fn add_column(&mut self, column: Column) -> Self {
         if let CardElement::ColumnSet { columns, .. } = self {
             columns.push(column);
@@ -727,27 +749,16 @@ impl CardElement {
     }
 
     /// Set Separator
+    #[must_use]
     pub fn set_separator(&mut self, s: bool) -> Self {
         match self {
-            CardElement::TextBlock { separator, .. } => {
-                *separator = Some(s);
-            }
-            CardElement::FactSet { separator, .. } => {
-                *separator = Some(s);
-            }
-            CardElement::ColumnSet { separator, .. } => {
-                *separator = Some(s);
-            }
-            CardElement::Image { separator, .. } => {
-                *separator = Some(s);
-            }
-            CardElement::InputChoiceSet { separator, .. } => {
-                *separator = Some(s);
-            }
-            CardElement::InputText { separator, .. } => {
-                *separator = Some(s);
-            }
-            CardElement::InputToggle { separator, .. } => {
+            CardElement::TextBlock { separator, .. }
+            | CardElement::FactSet { separator, .. }
+            | CardElement::ColumnSet { separator, .. }
+            | CardElement::Image { separator, .. }
+            | CardElement::InputChoiceSet { separator, .. }
+            | CardElement::InputText { separator, .. }
+            | CardElement::InputToggle { separator, .. } => {
                 *separator = Some(s);
             }
             _ => {}
@@ -756,24 +767,15 @@ impl CardElement {
     }
 
     /// Set Spacing
+    #[must_use]
     pub fn set_spacing(&mut self, s: Spacing) -> Self {
         match self {
-            CardElement::TextBlock { spacing, .. } => {
-                *spacing = Some(s);
-            }
-            CardElement::FactSet { spacing, .. } => {
-                *spacing = Some(s);
-            }
-            CardElement::ColumnSet { spacing, .. } => {
-                *spacing = Some(s);
-            }
-            CardElement::Image { spacing, .. } => {
-                *spacing = Some(s);
-            }
-            CardElement::InputChoiceSet { spacing, .. } => {
-                *spacing = Some(s);
-            }
-            CardElement::InputText { spacing, .. } => {
+            CardElement::TextBlock { spacing, .. }
+            | CardElement::FactSet { spacing, .. }
+            | CardElement::ColumnSet { spacing, .. }
+            | CardElement::Image { spacing, .. }
+            | CardElement::InputChoiceSet { spacing, .. }
+            | CardElement::InputText { spacing, .. } => {
                 *spacing = Some(s);
             }
             _ => {}
@@ -791,6 +793,7 @@ impl CardElement {
     }
 
     /// Add action to actionSet
+    #[must_use]
     pub fn add_action_to_set(&mut self, action: Action) -> Self {
         if let CardElement::ActionSet { actions, .. } = self {
             actions.push(action);
@@ -831,12 +834,14 @@ pub struct Column {
 }
 
 impl From<&Column> for Column {
+    #[must_use]
     fn from(item: &Column) -> Self {
         item.clone()
     }
 }
 
 impl From<&mut Column> for Column {
+    #[must_use]
     fn from(item: &mut Column) -> Self {
         item.clone()
     }
@@ -859,24 +864,28 @@ impl Column {
     }
 
     /// Adds element to column
+    #[must_use]
     pub fn add_element(&mut self, item: CardElement) -> Self {
         self.items.push(item);
         self.into()
     }
 
     /// Sets separator
+    #[must_use]
     pub fn set_separator(&mut self, s: bool) -> Self {
         self.separator = Some(s);
         self.into()
     }
 
     /// Sets `VerticalContentAlignment`
+    #[must_use]
     pub fn set_vertical_alignment(&mut self, s: VerticalContentAlignment) -> Self {
         self.vertical_content_alignment = Some(s);
         self.into()
     }
 
     /// Sets width
+    #[must_use]
     pub fn set_width<T: Into<String>>(&mut self, s: T) -> Self {
         self.width = Some(s.into());
         self.into()

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ error_chain! {
     foreign_links {
         Io(std::io::Error);
         Json(SerdeError);
-        UTF8(std::string::FromUtf8Error);
+        UTF8(std::str::Utf8Error);
         Hyper(HyperError);
     }
     errors {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
+use crate::types::GlobalIdType;
 use hyper::{Error as HyperError, StatusCode};
 use serde_json::error::Error as SerdeError;
-use crate::types::GlobalIdType;
 
 error_chain! {
     foreign_links {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use crate::types::GlobalIdType;
 use hyper::{Error as HyperError, StatusCode};
 use serde_json::error::Error as SerdeError;
 
@@ -35,9 +34,9 @@ error_chain! {
             display("{} {}", e, t)
         }
 
-        IncorrectId(expected: GlobalIdType, actual: GlobalIdType) {
-            description("Incorrect ID type")
-            display("Expected ID type {}, got {}", expected, actual)
+        Api(s: &'static str) {
+            description("The Webex API has changed, breaking the library's assumptions. This should be resolved in the next library update.")
+            display("API changed: {}", s)
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use hyper::{Error as HyperError, StatusCode};
 use serde_json::error::Error as SerdeError;
+use crate::types::GlobalIdType;
 
 error_chain! {
     foreign_links {
@@ -32,6 +33,11 @@ error_chain! {
         Tungstenite(e: tokio_tungstenite::tungstenite::Error, t: String) {
             description("Failed WS")
             display("{} {}", e, t)
+        }
+
+        IncorrectId(expected: GlobalIdType, actual: GlobalIdType) {
+            description("Incorrect ID type")
+            display("Expected ID type {}, got {}", expected, actual)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,9 +404,12 @@ impl Webex {
     }
 
     /// Delete a message by ID
+    #[deprecated(
+        since = "0.9.0",
+        note = "Please use `webex::delete::<Message>(id)` instead"
+    )]
     pub async fn delete_message(&self, id: &GlobalId) -> Result<(), Error> {
-        let rest_method = format!("messages/{}", id.id());
-        self.api_delete(rest_method.as_str()).await
+        self.delete::<Message>(id).await
     }
 
     /// Get available rooms
@@ -481,6 +484,18 @@ impl Webex {
         self.api_get::<T>(rest_method.as_str()).await.chain_err(|| {
             format!(
                 "Failed to get {} with id {:?}",
+                std::any::type_name::<T>(),
+                id
+            )
+        })
+    }
+
+    /// Delete a resource from an ID
+    pub async fn delete<T: Gettable + DeserializeOwned>(&self, id: &GlobalId) -> Result<(), Error> {
+        let rest_method = format!("{}/{}", T::API_ENDPOINT, id.id());
+        self.api_delete(rest_method.as_str()).await.chain_err(|| {
+            format!(
+                "Failed to delete {} with id {:?}",
                 std::any::type_name::<T>(),
                 id
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -655,7 +655,7 @@ impl From<&Message> for MessageOut {
     fn from(msg: &Message) -> Self {
         let mut new_msg = Self::default();
 
-        if msg.room_type == Some("group".to_string()) {
+        if msg.room_type == Some(RoomType::Group) {
             new_msg.room_id = msg.room_id.clone();
         } else if let Some(person_id) = &msg.person_id {
             new_msg.to_person_id = Some(person_id.clone());
@@ -664,6 +664,22 @@ impl From<&Message> for MessageOut {
         }
 
         new_msg
+    }
+}
+
+impl Message {
+    /// Reply to a message.
+    /// Posts the reply in the same chain as the replied-to message.
+    /// Contrast with [`MessageOut::from()`] which only replies in the same room.
+    #[must_use]
+    pub fn reply(&self) -> MessageOut {
+        let mut msg = MessageOut::from(self);
+        msg.parent_id = self
+            .parent_id
+            .as_deref()
+            .or(self.id.as_deref())
+            .map(ToOwned::to_owned);
+        msg
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,7 @@ impl Webex {
 
     /// Get list of organizations
     #[deprecated(
-        since = "0.9.0",
+        since = "0.5.2",
         note = "Please use `webex::list::<Organization>()` instead"
     )]
     pub async fn get_orgs(&self) -> Result<Vec<Organization>, Error> {
@@ -387,7 +387,7 @@ impl Webex {
     /// Retrieves the attachment for the given ID.  This can be used to
     /// retrieve data from an `AdaptiveCard` submission
     #[deprecated(
-        since = "0.9.0",
+        since = "0.5.2",
         note = "Please use `webex::get::<AttachmentAction>(id)` instead"
     )]
     pub async fn get_attachment_action(&self, id: &GlobalId) -> Result<AttachmentAction, Error> {
@@ -396,7 +396,7 @@ impl Webex {
 
     /// Get a message by ID
     #[deprecated(
-        since = "0.9.0",
+        since = "0.5.2",
         note = "Please use `webex::get::<Message>(id)` instead"
     )]
     pub async fn get_message(&self, id: &GlobalId) -> Result<Message, Error> {
@@ -405,7 +405,7 @@ impl Webex {
 
     /// Delete a message by ID
     #[deprecated(
-        since = "0.9.0",
+        since = "0.5.2",
         note = "Please use `webex::delete::<Message>(id)` instead"
     )]
     pub async fn delete_message(&self, id: &GlobalId) -> Result<(), Error> {
@@ -413,7 +413,7 @@ impl Webex {
     }
 
     /// Get available rooms
-    #[deprecated(since = "0.9.0", note = "Please use `webex::list::<Room>()` instead")]
+    #[deprecated(since = "0.5.2", note = "Please use `webex::list::<Room>()` instead")]
     pub async fn get_rooms(&self) -> Result<Vec<Room>, Error> {
         self.list().await
     }
@@ -439,14 +439,14 @@ impl Webex {
     }
 
     /// Get available room
-    #[deprecated(since = "0.9.0", note = "Please use `webex::get::<Room>(id)` instead")]
+    #[deprecated(since = "0.5.2", note = "Please use `webex::get::<Room>(id)` instead")]
     pub async fn get_room(&self, id: &GlobalId) -> Result<Room, Error> {
         self.get(id).await
     }
 
     /// Get information about person
     #[deprecated(
-        since = "0.9.0",
+        since = "0.5.2",
         note = "Please use `webex::get::<Person>(id)` instead"
     )]
     pub async fn get_person(&self, id: &GlobalId) -> Result<Person, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,9 +211,9 @@ impl WebexEventStream {
                                 debug!("Authentication succeeded");
                                 Ok(())
                             }
-                            _ => Err(format!("Received {:?} in reply to auth message", msg).into()),
+                            _ => Err(format!("Received {msg:?} in reply to auth message").into()),
                         },
-                        Err(e) => Err(format!("Received error from websocket: {}", e).into()),
+                        Err(e) => Err(format!("Received error from websocket: {e}").into()),
                     },
                     None => Err("Websocket closed".to_string().into()),
                 }
@@ -241,13 +241,13 @@ impl Webex {
             id,
             client,
             token: token.to_string(),
-            bearer: format!("Bearer {}", token),
+            bearer: format!("Bearer {token}"),
             host_prefix: HashMap::new(),
             device: DeviceData {
                 device_name: Some("rust-client".to_string()),
                 device_type: Some("DESKTOP".to_string()),
                 localized_model: Some("rust".to_string()),
-                model: Some(format!("rust-v{}", CRATE_VERSION)),
+                model: Some(format!("rust-v{CRATE_VERSION}")),
                 name: Some("rust-spark-client".to_string()),
                 system_name: Some("rust-spark-client".to_string()),
                 system_version: Some(CRATE_VERSION.to_string()),
@@ -368,7 +368,7 @@ impl Webex {
             return Err("Can't get mercury URL with no orgs".into());
         }
         let org_id = &orgs[0].id;
-        let api_url = format!("limited/catalog?format=hostmap&orgId={}", org_id);
+        let api_url = format!("limited/catalog?format=hostmap&orgId={org_id}");
         let catalogs = self.api_get::<CatalogReply>(&api_url).await?;
         let mercury_url = catalogs.service_links.wdm;
 
@@ -429,10 +429,10 @@ impl Webex {
             .collect();
         let futures: Vec<_> = team_endpoints
             .iter()
-            .map(|endpoint| self.api_get::<ListResult<Room>>(&endpoint))
+            .map(|endpoint| self.api_get::<ListResult<Room>>(endpoint))
             .collect();
         let teams_rooms = try_join_all(futures).await?;
-        for room in teams_rooms.into_iter() {
+        for room in teams_rooms {
             all_rooms.extend(room.items);
         }
         Ok(all_rooms)
@@ -561,7 +561,7 @@ impl Webex {
             .host_prefix
             .get(rest_method_trimmed)
             .unwrap_or(&default_prefix);
-        let url = format!("{}/{}", prefix, rest_method);
+        let url = format!("{prefix}/{rest_method}");
         debug!("Calling {} {:?}", http_method, url);
         let mut builder = Request::builder()
             .method(http_method)
@@ -628,7 +628,7 @@ impl Webex {
                     }
                 }
                 Error(ErrorKind::Limited(_, _), _) => Err(e),
-                _ => Err(format!("Can't decode devices reply: {}", e).into()),
+                _ => Err(format!("Can't decode devices reply: {e}").into()),
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@ pub use types::*;
 use error::{Error, ErrorKind, ResultExt};
 
 use crate::adaptive_card::AdaptiveCard;
-use futures::{future::try_join_all, try_join};
 use crate::types::Attachment;
+use futures::{future::try_join_all, try_join};
 use futures_util::{SinkExt, StreamExt};
 use hyper::{body::HttpBody, client::HttpConnector, Body, Client, Request};
 use hyper_tls::HttpsConnector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,7 +542,11 @@ impl Webex {
         let reply = self
             .call_web_api_raw(http_method, rest_method, body)
             .await?;
-        serde_json::from_str(reply.as_str()).map_err(|e| {
+        let mut reply_str = reply.as_str();
+        if reply_str.is_empty() {
+            reply_str = "null";
+        }
+        serde_json::from_str(reply_str).map_err(|e| {
             debug!("Couldn't parse reply for {} call: {}", rest_method, e);
             debug!("Source JSON: {}", reply);
             Error::with_chain(e, "failed to parse reply")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,8 +336,8 @@ impl Webex {
             catalogs = Some(
                 s.spawn(move || {
                     let orgs = rt.block_on(self.get_orgs())?;
-                    if orgs.len() != 1 {
-                        panic!("Can only get mercury URL if account is part of exactly one org");
+                    if orgs.is_empty() {
+                        return Err(error::Error::from("Can't get mercury URL with no orgs"));
                     }
                     let org_id = &orgs[0].id;
                     let api_url = format!("limited/catalog?format=hostmap&orgId={}", org_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ impl Webex {
                     is_open: true,
                 })
             }
-            Err(e) => Err(Into::<Error>::into(format!("connecting to {}, {}", url, e))),
+            Err(e) => Err(format!("connecting to {}, {}", url, e).into()),
         }
     }
 
@@ -297,8 +297,7 @@ impl Webex {
     /// # Errors
     /// See [`Webex::get_message()`] errors.
     pub async fn get_attachment_action(&self, id: &GlobalId) -> Result<AttachmentAction, Error> {
-        id.expect_type(GlobalIdType::AttachmentAction)?;
-        let rest_method = format!("attachment/actions/{}", id.id());
+        let rest_method = format!("attachment/actions/{}", id.id(GlobalIdType::AttachmentAction)?);
         self.api_get(rest_method.as_str()).await
     }
     
@@ -322,15 +321,13 @@ impl Webex {
     /// * (New) [`ErrorKind::IncorrectId`] - this function has been passed a ``GlobalId`` that does not
     /// correspond to a message.
     pub async fn get_message(&self, id: &GlobalId) -> Result<Message, Error> {
-        id.expect_type(GlobalIdType::Message)?;
-        let rest_method = format!("messages/{}", id.id());
+        let rest_method = format!("messages/{}", id.id(GlobalIdType::Message)?);
         self.api_get(rest_method.as_str()).await
     }
 
     /// Delete a message by ID
     pub async fn delete_message(&self, id: &GlobalId) -> Result<(), Error> {
-        id.expect_type(GlobalIdType::Message)?;
-        let rest_method = format!("messages/{}", id.id());
+        let rest_method = format!("messages/{}", id.id(GlobalIdType::Message)?);
         self.api_delete(rest_method.as_str()).await
     }
 
@@ -345,8 +342,7 @@ impl Webex {
 
     /// Get available room
     pub async fn get_room(&self, id: &GlobalId) -> Result<Room, Error> {
-        id.expect_type(GlobalIdType::Room)?;
-        let rest_method = format!("rooms/{}", id.id());
+        let rest_method = format!("rooms/{}", id.id(GlobalIdType::Room)?);
         let room_reply: Result<Room, _> = self.api_get(rest_method.as_str()).await;
         match room_reply {
             Err(e) => Err(Error::with_chain(e, "room failed: ")),
@@ -359,8 +355,7 @@ impl Webex {
     /// # Errors
     /// See `get_message`
     pub async fn get_person(&self, id: &GlobalId) -> Result<Person, Error> {
-        id.expect_type(GlobalIdType::Person)?;
-        let rest_method = format!("people/{}", id.id());
+        let rest_method = format!("people/{}", id.id(GlobalIdType::Person)?);
         let people_reply: Result<Person, _> = self.api_get(rest_method.as_str()).await;
         match people_reply {
             Err(e) => Err(Error::with_chain(e, "people failed: ")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ impl Webex {
 
     /// Get list of organizations
     #[deprecated(
-        since = "0.5.2",
+        since = "0.6.3",
         note = "Please use `webex::list::<Organization>()` instead"
     )]
     pub async fn get_orgs(&self) -> Result<Vec<Organization>, Error> {
@@ -388,7 +388,7 @@ impl Webex {
     /// Retrieves the attachment for the given ID.  This can be used to
     /// retrieve data from an `AdaptiveCard` submission
     #[deprecated(
-        since = "0.5.2",
+        since = "0.6.3",
         note = "Please use `webex::get::<AttachmentAction>(id)` instead"
     )]
     pub async fn get_attachment_action(&self, id: &GlobalId) -> Result<AttachmentAction, Error> {
@@ -397,7 +397,7 @@ impl Webex {
 
     /// Get a message by ID
     #[deprecated(
-        since = "0.5.2",
+        since = "0.6.3",
         note = "Please use `webex::get::<Message>(id)` instead"
     )]
     pub async fn get_message(&self, id: &GlobalId) -> Result<Message, Error> {
@@ -406,7 +406,7 @@ impl Webex {
 
     /// Delete a message by ID
     #[deprecated(
-        since = "0.5.2",
+        since = "0.6.3",
         note = "Please use `webex::delete::<Message>(id)` instead"
     )]
     pub async fn delete_message(&self, id: &GlobalId) -> Result<(), Error> {
@@ -414,7 +414,7 @@ impl Webex {
     }
 
     /// Get available rooms
-    #[deprecated(since = "0.5.2", note = "Please use `webex::list::<Room>()` instead")]
+    #[deprecated(since = "0.6.3", note = "Please use `webex::list::<Room>()` instead")]
     pub async fn get_rooms(&self) -> Result<Vec<Room>, Error> {
         self.list().await
     }
@@ -440,14 +440,14 @@ impl Webex {
     }
 
     /// Get available room
-    #[deprecated(since = "0.5.2", note = "Please use `webex::get::<Room>(id)` instead")]
+    #[deprecated(since = "0.6.3", note = "Please use `webex::get::<Room>(id)` instead")]
     pub async fn get_room(&self, id: &GlobalId) -> Result<Room, Error> {
         self.get(id).await
     }
 
     /// Get information about person
     #[deprecated(
-        since = "0.5.2",
+        since = "0.6.3",
         note = "Please use `webex::get::<Person>(id)` instead"
     )]
     pub async fn get_person(&self, id: &GlobalId) -> Result<Person, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,8 @@ impl Webex {
     /// * [`ErrorKind::UTF8`] - returned when the request returns non-UTF8 code.
     /// * (New) [`ErrorKind::IncorrectId`] - this function has been passed a ``GlobalId`` that does not
     /// correspond to a message. This error will only occur in debug builds
-    /// (`#[cfg(debug_assertions)]`) for performance.
+    /// (`#[cfg(debug_assertions)]` enabled) for performance reasons, and because an incorrect ID
+    /// will not cause crashes - this is purely to ease debugging if something goes wrong
     pub async fn get_message(&self, id: &GlobalId) -> Result<Message, Error> {
         let rest_method = format!("messages/{}", id.id(GlobalIdType::Message)?);
         self.api_get(rest_method.as_str()).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 // TODO: remove this when clippy bug fixed in stable
 #![allow(clippy::use_self)]
 #![allow(clippy::missing_errors_doc)]
+#![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, deny(warnings))]
 #![doc(html_root_url = "https://docs.rs/webex/0.2.0/webex/")]
 
@@ -319,11 +320,7 @@ impl Webex {
         }
 
         // Failed to connect to any existing devices, creating new one
-        if let Ok(event_stream) = connect_device(self, self.setup_devices().await?).await {
-            Ok(event_stream)
-        } else {
-            Err("Failed to connect to any existing device and newly created device".into())
-        }
+        connect_device(self, self.setup_devices().await?).await
     }
 
     async fn get_mercury_url(&self) -> Result<String, Option<error::Error>> {
@@ -342,10 +339,7 @@ impl Webex {
         let mercury_url = self.get_mercury_url_uncached().await;
 
         if let Ok(mut cache) = MERCURY_CACHE.lock() {
-            let result = match mercury_url {
-                Ok(ref url) => Ok(url.clone()),
-                Err(_) => Err(()),
-            };
+            let result = mercury_url.as_ref().map_or(Err(()), |url| Ok(url.clone()));
             trace!("Saving mercury url to cache: {}=>{:?}", self.id, &result);
             cache.insert(self.id, result);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,12 +527,16 @@ impl Webex {
                 }
                 match resp.status() {
                     hyper::StatusCode::LOCKED | hyper::StatusCode::TOO_MANY_REQUESTS => {
-                        warn!("Limited");
                         let retry_after = resp
                             .headers()
                             .get("Retry-After")
                             .and_then(|s| s.to_str().ok())
                             .and_then(|t| t.parse::<i64>().ok());
+                        warn!(
+                            "Limited calling {} {}/{}",
+                            http_method, prefix, rest_method_trimmed
+                        );
+                        debug!("Retry-After: {:?}", retry_after);
                         Err(ErrorKind::Limited(resp.status(), retry_after).into())
                     }
                     status if !status.is_success() => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,7 +548,7 @@ impl Webex {
         }
         serde_json::from_str(reply_str).map_err(|e| {
             debug!("Couldn't parse reply for {} call: {}", rest_method, e);
-            debug!("Source JSON: {}", reply);
+            debug!("Source JSON: `{}`", reply_str);
             Error::with_chain(e, "failed to parse reply")
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,8 +373,7 @@ impl Webex {
     /// # Errors
     /// See [`Webex::get_message()`] errors.
     pub async fn get_attachment_action(&self, id: &GlobalId) -> Result<AttachmentAction, Error> {
-        debug_assert!(id.id(GlobalIdType::AttachmentAction).is_ok());
-        let rest_method = format!("attachment/actions/{}", id.id_unchecked());
+        let rest_method = format!("attachment/actions/{}", id.id(GlobalIdType::AttachmentAction)?);
         self.api_get(rest_method.as_str()).await
     }
 
@@ -396,17 +395,16 @@ impl Webex {
     /// reported.)
     /// * [`ErrorKind::UTF8`] - returned when the request returns non-UTF8 code.
     /// * (New) [`ErrorKind::IncorrectId`] - this function has been passed a ``GlobalId`` that does not
-    /// correspond to a message.
+    /// correspond to a message. This error will only occur in debug builds
+    /// (`#[cfg(debug_assertions)]`) for performance.
     pub async fn get_message(&self, id: &GlobalId) -> Result<Message, Error> {
-        debug_assert!(id.id(GlobalIdType::Message).is_ok());
-        let rest_method = format!("messages/{}", id.id_unchecked());
+        let rest_method = format!("messages/{}", id.id(GlobalIdType::Message)?);
         self.api_get(rest_method.as_str()).await
     }
 
     /// Delete a message by ID
     pub async fn delete_message(&self, id: &GlobalId) -> Result<(), Error> {
-        debug_assert!(id.id(GlobalIdType::Message).is_ok());
-        let rest_method = format!("messages/{}", id.id_unchecked());
+        let rest_method = format!("messages/{}", id.id(GlobalIdType::Message)?);
         self.api_delete(rest_method.as_str()).await
     }
 
@@ -421,8 +419,7 @@ impl Webex {
 
     /// Get available room
     pub async fn get_room(&self, id: &GlobalId) -> Result<Room, Error> {
-        debug_assert!(id.id(GlobalIdType::Room).is_ok());
-        let rest_method = format!("rooms/{}", id.id_unchecked());
+        let rest_method = format!("rooms/{}", id.id(GlobalIdType::Room)?);
         let room_reply: Result<Room, _> = self.api_get(rest_method.as_str()).await;
         match room_reply {
             Err(e) => Err(Error::with_chain(e, "room failed: ")),
@@ -435,8 +432,7 @@ impl Webex {
     /// # Errors
     /// See `get_message`
     pub async fn get_person(&self, id: &GlobalId) -> Result<Person, Error> {
-        debug_assert!(id.id(GlobalIdType::Person).is_ok());
-        let rest_method = format!("people/{}", id.id_unchecked());
+        let rest_method = format!("people/{}", id.id(GlobalIdType::Person)?);
         let people_reply: Result<Person, _> = self.api_get(rest_method.as_str()).await;
         match people_reply {
             Err(e) => Err(Error::with_chain(e, "people failed: ")),

--- a/src/types.rs
+++ b/src/types.rs
@@ -754,21 +754,17 @@ impl GlobalId {
         Ok(())
     }
     /// Returns the base64 geo-ID as a ``&str`` for use in API requests.
-    /// Takes an expected type to ensure that the ID is for the correct type of object.
+    /// Takes an expected type to ensure that the ID is for the correct type of object, but only
+    /// performs that checking on debug builds as an incorrect ID type is not a hard error.
     pub fn id(&self, expected: GlobalIdType) -> Result<&str, error::Error> {
+        #[cfg(debug_assertions)]
         if self.type_ == expected {
-            Ok(self.id_unchecked())
+            Ok(&self.id)
         } else {
             Err(ErrorKind::IncorrectId(expected, self.type_).into())
         }
-    }
-    /// Returns the base64 geo-ID as a ``&str`` for use in API requests.
-    /// Does not check the ID type, useful when performance is critical.
-    /// It is always safe to use this rather than `.id()` - the worst that'll happen is a 404 error
-    /// from the API.
-    #[must_use]
-    pub fn id_unchecked(&self) -> &str {
-        &self.id
+        #[cfg(not(debug_assertions))]
+        Ok(&self.id)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -389,7 +389,7 @@ impl Authorization {
             id: Uuid::new_v4().to_string(),
             auth_type: "authorization".to_string(),
             data: AuthToken {
-                token: format!("Bearer {}", token),
+                token: format!("Bearer {token}"),
             },
         }
     }
@@ -784,8 +784,8 @@ impl GlobalId {
             Ok(())
         } else {
             Err(format!(
-                "GlobalId type {} does not match expected type {}",
-                self.type_, expected_type
+                "GlobalId type {} does not match expected type {expected_type}",
+                self.type_
             )
             .into())
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -601,7 +601,10 @@ impl From<ActivityType> for GlobalIdType {
             ActivityType::Message(_) => Self::Message,
             ActivityType::Unknown(_) => Self::Unknown,
             a => {
-                log::error!("Failed to convert {:?} to GlobalIdType, this may cause errors later", a);
+                log::error!(
+                    "Failed to convert {:?} to GlobalIdType, this may cause errors later",
+                    a
+                );
                 Self::Unknown
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -167,6 +167,17 @@ pub struct MessageOut {
     pub attachments: Option<Vec<Attachment>>,
 }
 
+/// Type of room
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RoomType {
+    #[default]
+    /// 1:1 private chat
+    Direct,
+    /// Group room
+    Group,
+}
+
 /// Webex Teams message information
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
@@ -178,11 +189,8 @@ pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The room type.
-    ///
-    /// direct - 1:1 room
-    /// group - group room
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub room_type: Option<String>,
+    pub room_type: Option<RoomType>,
     /// The person ID of the recipient when sending a private 1:1 message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_id: Option<String>,
@@ -481,7 +489,10 @@ pub enum ActivityType {
 pub enum MessageActivity {
     /// A message was posted
     Posted,
-    /// A message was forwarded
+    /// A message was posted with attachments
+    /// TODO: Should this be merged with [`Self::Posted`]? Could have a field to determine
+    /// attachments/no attachments, or we can let the user figure that out from the message
+    /// instance.
     Shared,
     /// A message was acknowledged
     Acknowledged,
@@ -596,7 +607,7 @@ impl Event {
             "status.start_typing" => ActivityType::StartTyping,
             "locus.difference" => ActivityType::Locus,
             "janus.user_sessions" => ActivityType::Janus,
-
+            //"apheleia.subscription_update" ??
             e => {
                 log::error!("Unknown data.event_type `{}`, returning Unknown", e);
                 ActivityType::Unknown(e.to_string())

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,8 +12,8 @@ pub(crate) use api::Gettable;
 mod api {
     //! Private crate to hold all types that the user shouldn't have to interact with.
     use super::{AttachmentAction, Message, Organization, Person, Room, Team};
-    /// Trait for API types. Has to be public due to trait bounds limitations on webex API, but
-    /// not recommended to implement yourself.
+    /// Trait for API types. Has to be public due to trait bounds limitations on webex API, but hidden
+    /// in a private crate so users don't see it.
     pub trait Gettable {
         /// Endpoint to query to perform an HTTP GET request with an id
         const API_ENDPOINT: &'static str;
@@ -467,7 +467,6 @@ pub enum ActivityType {
     /// `conversation.activity` type (belonging in Message or Space), the string will be
     /// `"conversation.activity.{event.data.activity.verb}"`, for example it would be
     /// `"conversation.activity.post"` for `Message(MessageActivity::Posted)`
-    ///
     Unknown(String),
 }
 /// Specifics of what type of activity [`ActivityType::Message`] represents.

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,31 +7,41 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use uuid::Uuid;
 
-/// Trait for API types. Has to be public due to trait bounds limitations on webex API, but
-/// not recommended to implement yourself.
-pub trait Gettable {
-    /// Endpoint to query to perform an HTTP GET request with an id
-    const API_ENDPOINT: &'static str;
-}
+pub(crate) use api::Gettable;
 
-impl Gettable for Message {
-    const API_ENDPOINT: &'static str = "messages";
-}
+mod api {
+    //! Private crate to hold all types that the user shouldn't have to interact with.
+    use super::{AttachmentAction, Message, Organization, Person, Room, Team};
+    /// Trait for API types. Has to be public due to trait bounds limitations on webex API, but
+    /// not recommended to implement yourself.
+    pub trait Gettable {
+        /// Endpoint to query to perform an HTTP GET request with an id
+        const API_ENDPOINT: &'static str;
+    }
 
-impl Gettable for Organization {
-    const API_ENDPOINT: &'static str = "organizations";
-}
+    impl Gettable for Message {
+        const API_ENDPOINT: &'static str = "messages";
+    }
 
-impl Gettable for AttachmentAction {
-    const API_ENDPOINT: &'static str = "attachment/actions";
-}
+    impl Gettable for Organization {
+        const API_ENDPOINT: &'static str = "organizations";
+    }
 
-impl Gettable for Room {
-    const API_ENDPOINT: &'static str = "rooms";
-}
+    impl Gettable for AttachmentAction {
+        const API_ENDPOINT: &'static str = "attachment/actions";
+    }
 
-impl Gettable for Person {
-    const API_ENDPOINT: &'static str = "people";
+    impl Gettable for Room {
+        const API_ENDPOINT: &'static str = "rooms";
+    }
+
+    impl Gettable for Person {
+        const API_ENDPOINT: &'static str = "people";
+    }
+
+    impl Gettable for Team {
+        const API_ENDPOINT: &'static str = "teams";
+    }
 }
 
 #[derive(Deserialize)]
@@ -76,6 +86,20 @@ pub struct Organization {
     pub display_name: String,
     /// Date and time the org was created
     pub created: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+/// Holds details about a team that includes the account.
+pub struct Team {
+    /// Id of the team
+    pub id: String,
+    /// Name of the team
+    pub name: String,
+    /// Date and time the team was created
+    pub created: String,
+    /// Team description
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -401,7 +401,7 @@ pub(crate) struct AuthToken {
 pub struct Actor {
     pub id: String,
     pub object_type: String,
-    pub display_name: String,
+    pub display_name: Option<String>,
     pub org_id: Option<String>,
     pub email_address: Option<String>,
     #[serde(rename = "entryUUID")]
@@ -488,7 +488,8 @@ pub enum MessageActivity {
 pub enum SpaceActivity {
     /// A new space was created with the bot
     Created,
-    /// Bot was added to a space
+    /// Bot was added to a space... or a reaction was added to a message?
+    /// TODO: figure out a way to tell these events apart
     Joined,
     /// Bot left (was kicked out of) a space
     Left,

--- a/src/types.rs
+++ b/src/types.rs
@@ -417,7 +417,7 @@ pub struct Activity {
 }
 
 /// Get what activity an [`Activity`] represents.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ActivityType {
     /// Message changed - see [`MessageActivity`] for details.
     Message(MessageActivity),
@@ -431,7 +431,7 @@ pub enum ActivityType {
     Unknown,
 }
 /// Specifics of what type of activity [`ActivityType::Message`] represents.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MessageActivity {
     /// A message was posted
     Posted,
@@ -443,7 +443,7 @@ pub enum MessageActivity {
     Deleted,
 }
 /// Specifics of what type of activity [`ActivityType::Space`] represents.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SpaceActivity {
     /// Bot joined a space
     Created,

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use uuid::Uuid;
 
-pub(crate) use api::Gettable;
+pub(crate) use api::{Gettable, ListResult};
 
 mod api {
     //! Private crate to hold all types that the user shouldn't have to interact with.
@@ -42,11 +42,11 @@ mod api {
     impl Gettable for Team {
         const API_ENDPOINT: &'static str = "teams";
     }
-}
 
-#[derive(Deserialize)]
-pub(crate) struct ListResult<T> {
-    pub items: Vec<T>,
+    #[derive(crate::types::Deserialize)]
+    pub struct ListResult<T> {
+        pub items: Vec<T>,
+    }
 }
 
 /// Webex Teams room information

--- a/src/types.rs
+++ b/src/types.rs
@@ -535,6 +535,7 @@ impl Event {
                     .expect("Conversation activity should have activity set")
                     .verb
                     .as_str();
+                #[allow(clippy::option_if_let_else)]
                 if let Ok(type_) = MessageActivity::try_from(activity_type) {
                     ActivityType::Message(type_)
                 } else if let Ok(type_) = SpaceActivity::try_from(activity_type) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -460,15 +460,15 @@ impl GlobalId {
     ///   * the ID is neither a UUID or a base64 geo-id.
     ///
     /// # Examples
+    /// Basic behaviour: default cluster, type-checking ID
     /// ```
     /// use webex::{GlobalId, GlobalIdType};
     /// // Create a new GlobalId
     /// // Note: you should never need to do this in your code.
     /// // Is making all this public a code smell?
-    /// let id = GlobalId::new_with_cluster(
+    /// let id = GlobalId::new(
     ///     GlobalIdType::Message,
-    ///     "0fad2000-f9f5-11eb-9eee-79a3ef978a3d".to_string(),
-    ///     None)?;
+    ///     "0fad2000-f9f5-11eb-9eee-79a3ef978a3d".to_string())?;
     /// // Show off type-checked IDs - ensure that the ID passed into a function is the one
     /// // expected.
     /// assert_eq!(id.id(GlobalIdType::Message)?,

--- a/src/types.rs
+++ b/src/types.rs
@@ -348,7 +348,7 @@ impl Authorization {
     /// id is a random UUID v4
     #[must_use]
     pub fn new(token: &str) -> Self {
-        Authorization {
+        Self {
             id: Uuid::new_v4().to_string(),
             type_: "authorization".to_string(),
             data: AuthToken {
@@ -511,7 +511,7 @@ impl TryFrom<&str> for SpaceActivity {
 impl MessageActivity {
     /// True if this is a new message ([`Self::Posted`] or [`Self::Shared`]).
     #[must_use]
-    pub fn is_created(&self) -> bool {
+    pub const fn is_created(&self) -> bool {
         matches!(*self, Self::Posted | Self::Shared)
     }
 }
@@ -626,11 +626,11 @@ impl std::fmt::Display for GlobalIdType {
             f,
             "{}",
             match self {
-                GlobalIdType::Message => "MESSAGE",
-                GlobalIdType::Person => "PEOPLE",
-                GlobalIdType::Room => "ROOM",
-                GlobalIdType::AttachmentAction => "ATTACHMENT_ACTION",
-                GlobalIdType::Unknown => "<UNKNOWN>",
+                Self::Message => "MESSAGE",
+                Self::Person => "PEOPLE",
+                Self::Room => "ROOM",
+                Self::AttachmentAction => "ATTACHMENT_ACTION",
+                Self::Unknown => "<UNKNOWN>",
             }
         )
     }
@@ -763,6 +763,8 @@ impl GlobalId {
     /// ```should_panic
     /// # use webex::*;
     /// let id = GlobalId::new(GlobalIdType::Message, "id".to_string()).unwrap();
+    /// // Panics, because expected type `Room` doesn't match actual type `Message`
+    /// // Wouldn't panic in release mode.
     /// id.id(GlobalIdType::Room).expect("Get ID of type room");
     /// ```
     #[inline]

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 /// Webex Teams room information
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Room {
     /// A unique identifier for the room.
     pub id: String,
@@ -21,25 +22,21 @@ pub struct Room {
     #[serde(rename = "type")]
     pub room_type: String,
     /// Whether the room is moderated (locked) or not.
-    #[serde(rename = "isLocked")]
     pub is_locked: bool,
     /// The ID for the team with which this room is associated.
-    #[serde(rename = "teamId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub team_id: Option<String>,
     /// The date and time of the room's last activity.
-    #[serde(rename = "lastActivity")]
     pub last_activity: String,
     /// The ID of the person who created this room.
-    #[serde(rename = "creatorId")]
     pub creator_id: String,
     /// The date and time the room was created.
     pub created: String,
 }
 
-/// API reply holding the room vector
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug)]
-pub struct RoomsReply {
+pub(crate) struct RoomsReply {
     pub items: Vec<Room>,
 }
 
@@ -55,17 +52,14 @@ pub struct Organization {
     pub created: String,
 }
 
-/// API reply holding the orgs a person belongs to
 #[derive(Deserialize, Serialize, Debug)]
-pub struct OrganizationReply {
-    /// List of orgs returned
+pub(crate) struct OrganizationReply {
     pub items: Vec<Organization>,
 }
 
-#[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct CatalogReply {
+pub(crate) struct CatalogReply {
     pub service_links: Catalog,
 }
 #[allow(missing_docs)]
@@ -98,18 +92,19 @@ pub struct Catalog {
 
 /// Outgoing message
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageOut {
     /// The parent message to reply to.
-    #[serde(rename = "parentId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
     /// The room ID of the message.
-    #[serde(rename = "roomId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The person ID of the recipient when sending a private 1:1 message.
-    #[serde(rename = "toPersonId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_id: Option<String>,
     /// The email address of the recipient when sending a private 1:1 message.
-    #[serde(rename = "toPersonEmail", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_email: Option<String>,
     /// The message, in plain text. If markdown is specified this parameter may be optionally used to provide alternate text for UI clients that do not support rich text. The maximum message length is 7439 bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -127,24 +122,25 @@ pub struct MessageOut {
 
 /// Webex Teams message information
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Message {
     /// The unique identifier for the message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// The room ID of the message.
-    #[serde(rename = "roomId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The room type.
     ///
     /// direct - 1:1 room
     /// group - group room
-    #[serde(rename = "roomType", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_type: Option<String>,
     /// The person ID of the recipient when sending a private 1:1 message.
-    #[serde(rename = "toPersonId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_id: Option<String>,
     /// The email address of the recipient when sending a private 1:1 message.
-    #[serde(rename = "toPersonEmail", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_email: Option<String>,
     /// The message, in plain text. If markdown is specified this parameter may be optionally used to provide alternate text for UI clients that do not support rich text.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -159,16 +155,16 @@ pub struct Message {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<String>>,
     /// The person ID of the message author.
-    #[serde(rename = "personId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub person_id: Option<String>,
     /// The email address of the message author.
-    #[serde(rename = "personEmail", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub person_email: Option<String>,
     /// People IDs for anyone mentioned in the message.
-    #[serde(rename = "mentionedPeople", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mentioned_people: Option<Vec<String>>,
     /// Group names for the groups mentioned in the message.
-    #[serde(rename = "mentionedGroups", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mentioned_groups: Option<Vec<String>>,
     /// Message content attachments attached to the message.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -181,17 +177,13 @@ pub struct Message {
     pub updated: Option<String>,
 }
 
-/// API Message reply
-#[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug)]
-pub struct MessagesReply {
+pub(crate) struct MessagesReply {
     pub items: Vec<Message>,
 }
 
-/// API Empty reply
-#[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug)]
-pub struct EmptyReply {}
+pub(crate) struct EmptyReply {}
 
 /// API Error
 #[allow(missing_docs)]
@@ -202,7 +194,7 @@ pub struct Error {
 
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug)]
-pub struct DevicesReply {
+pub(crate) struct DevicesReply {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub devices: Option<Vec<DeviceData>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -339,8 +331,8 @@ pub struct DeviceSettings {
 pub struct Authorization {
     pub id: String,
     #[serde(rename = "type")]
-    pub type_: String,
-    pub data: AuthToken,
+    pub auth_type: String,
+    data: AuthToken,
 }
 
 impl Authorization {
@@ -350,7 +342,7 @@ impl Authorization {
     pub fn new(token: &str) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
-            type_: "authorization".to_string(),
+            auth_type: "authorization".to_string(),
             data: AuthToken {
                 token: format!("Bearer {}", token),
             },
@@ -358,23 +350,19 @@ impl Authorization {
     }
 }
 
-#[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
-pub struct AuthToken {
+pub(crate) struct AuthToken {
     pub token: String,
 }
 
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Actor {
     pub id: String,
-    #[serde(rename = "objectType")]
     pub object_type: String,
-    #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(rename = "orgId")]
     pub org_id: Option<String>,
-    #[serde(rename = "emailAddress")]
     pub email_address: Option<String>,
     #[serde(rename = "entryUUID")]
     pub entry_uuid: String,
@@ -384,12 +372,12 @@ pub struct Actor {
 
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct EventData {
-    #[serde(rename = "eventType")]
     pub event_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actor: Option<Actor>,
-    #[serde(rename = "conversationId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub conversation_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub activity: Option<Activity>,
@@ -397,9 +385,9 @@ pub struct EventData {
 
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Activity {
     pub id: String,
-    #[serde(rename = "objectType")]
     pub object_type: String,
     pub url: String,
     pub published: String,
@@ -408,11 +396,11 @@ pub struct Activity {
     pub object: Object,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<Target>,
-    #[serde(rename = "clientTempId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_temp_id: Option<String>,
-    #[serde(rename = "encryptionKeyUrl", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encryption_key_url: Option<String>,
-    #[serde(rename = "vectorCounters", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub vector_counters: Option<VectorCounters>,
 }
 
@@ -563,15 +551,11 @@ impl Event {
     /// all IDs).
     pub fn get_global_id(&self) -> Result<GlobalId, error::Error> {
         // Safety: ID should be fine since it's from the API (guaranteed to be UUID or b64 URI).
+        let self_activity = self.data.activity.as_ref();
         GlobalId::new_with_cluster_unchecked(
             self.activity_type().into(),
-            self.data
-                .activity
-                .as_ref()
-                .map_or_else(|| self.id.clone(), |a| a.id.clone()),
-            self.data
-                .activity
-                .as_ref()
+            self_activity.map_or_else(|| self.id.clone(), |a| a.id.clone()),
+            self_activity
                 .and_then(|a| a.target.as_ref())
                 .and_then(Target::get_cluster)
                 .as_deref(),
@@ -616,7 +600,10 @@ impl From<ActivityType> for GlobalIdType {
         match a {
             ActivityType::Message(_) => Self::Message,
             ActivityType::Unknown(_) => Self::Unknown,
-            _ => todo!(),
+            a => {
+                log::error!("Failed to convert {:?} to GlobalIdType, this may cause errors later", a);
+                Self::Unknown
+            }
         }
     }
 }
@@ -759,14 +746,6 @@ impl GlobalId {
     /// Returns the base64 geo-ID as a ``&str`` for use in API requests.
     /// Takes an expected type to ensure that the ID is for the correct type of object, but only
     /// performs that checking on debug builds as an incorrect ID type is not a hard error.
-    ///
-    /// ```should_panic
-    /// # use webex::*;
-    /// let id = GlobalId::new(GlobalIdType::Message, "id".to_string()).unwrap();
-    /// // Panics, because expected type `Room` doesn't match actual type `Message`
-    /// // Wouldn't panic in release mode.
-    /// id.id(GlobalIdType::Room).expect("Get ID of type room");
-    /// ```
     #[inline]
     pub fn id(&self, expected: GlobalIdType) -> Result<&str, error::Error> {
         if !cfg!(debug_assertions) || self.type_ == expected {
@@ -787,26 +766,25 @@ pub struct VectorCounters {
 
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Target {
     pub id: String,
-    #[serde(rename = "objectType")]
     pub object_type: String,
     pub url: String,
     pub participants: MiscItems,
     pub activities: MiscItems,
     pub tags: Vec<String>,
-    #[serde(rename = "globalId")]
     pub global_id: String,
 }
 
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct Object {
-    #[serde(rename = "objectType")]
     pub object_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mentions: Option<MiscItems>,
@@ -878,6 +856,7 @@ pub struct Attachment {
 
 /// Attachment action details
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct AttachmentAction {
     /// A unique identifier for the action.
     pub id: String,
@@ -885,16 +864,16 @@ pub struct AttachmentAction {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub action_type: Option<String>,
     /// The parent message the attachment action was performed on.
-    #[serde(rename = "messageId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
     /// The action's inputs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inputs: Option<HashMap<String, String>>,
     /// The ID of the person who performed the action.
-    #[serde(rename = "personId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub person_id: Option<String>,
     /// The ID of the room the action was performed within.
-    #[serde(rename = "roomId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The date and time the action was created.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -950,7 +929,7 @@ pub struct Person {
 
 /// Phone number information
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(default)]
 pub struct PhoneNumber {
     /// Phone number type
     #[serde(rename = "type")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,11 +2,11 @@
 //! Basic types for Webex Teams APIs
 
 use crate::{adaptive_card::AdaptiveCard, error, error::ResultExt};
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use uuid::Uuid;
-use base64::Engine;
 
 pub(crate) use api::{Gettable, ListResult};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,6 +137,18 @@ pub struct Catalog {
     pub webex_appapi_service: String,
 }
 
+/// Destination for a `MessageOut`
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum Destination {
+    /// Post a message in this room
+    RoomId(String),
+    /// Post a message to a person, using their user ID
+    ToPersonId(String),
+    /// Post a message to a person, using their email
+    ToPersonEmail(String),
+}
+
 /// Outgoing message
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
@@ -153,6 +165,10 @@ pub struct MessageOut {
     /// The email address of the recipient when sending a private 1:1 message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_email: Option<String>,
+    // TODO - should we use globalIDs? We should check this field before the message is sent
+    // rolls up room_id, to_person_id, and to_person_email all in one field :)
+    //#[serde(flatten)]
+    //pub deliver_to: Option<Destination>,
     /// The message, in plain text. If markdown is specified this parameter may be optionally used to provide alternate text for UI clients that do not support rich text. The maximum message length is 7439 bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -417,7 +417,7 @@ pub struct Activity {
 }
 
 /// Get what activity an [`Activity`] represents.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ActivityType {
     /// Message changed - see [`MessageActivity`] for details.
     Message(MessageActivity),
@@ -431,7 +431,7 @@ pub enum ActivityType {
     Unknown,
 }
 /// Specifics of what type of activity [`ActivityType::Message`] represents.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MessageActivity {
     /// A message was posted
     Posted,
@@ -443,7 +443,7 @@ pub enum MessageActivity {
     Deleted,
 }
 /// Specifics of what type of activity [`ActivityType::Space`] represents.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SpaceActivity {
     /// Bot joined a space
     Created,


### PR DESCRIPTION
## Webex 0.9.0
Working on:
* Stronger types for everything!
  * IDs
    * Still need some work - we don't want `assert`, just log errors
  * Activity types - no more `event.data.event_type = "conversation....?"` - now `event.activity_type() == ActivityType::Message(MessageActivity::Posted)` - clearer and harder to typo
    * Logs errors for unknown event types - should be nice and visible but shouldn't crash.
  * `#[must_use]` on constructors
* Related: improving library interface
  * `get_person()`/`get_room()`/... now just `Webex::get::<T>()` allowing for type inference and deduplication of code.
* More docs!
  * Trying to add docs for all new types, as well as adding docs for previously-existing types
* Pleasing Clippy
  * Hard work but very worth it - code now passes `clippy::pedantic` apart from given allows in code (e.g. `clippy::return_self_not_must_use` - this can be a bit of an antipattern in modifying builder methods) and of course remaining docs
* Also unhardcoded mercury device URL - may not work inside a boundary (e.g. government) but should work better for when we may have EU IDs etc.
  * Public-facing API change:`Webex::new()` is now async.
* Debug checks - in debug mode, checks that ID types match expected types. Should be no overhead for release mode.
  * TODO: debug checks should log rather than crash (i.e. work as release, receiving 404 errors, but with logs for better debugging).
  * Also TODO, do we want `Id::id(expected_type)` and `Id::id_unchecked()` - can we merge them into one? will the user ever need to get the ID from an event and will they care that they have to pass the expected type in?
* Fix `Webex::list()` - we should return iterators rather than vectors
  * This will let us do paging properly (which we don't do at all currently)
  * Allows the user the flexibility of `for room in Webex::list::<Room>() {}` vs `let rooms: Vec<_> = Webex::list()?.collect();`
* Allow the user to pass options to API calls
  * messages before/after a certain date, room list options (e.g. search inside a team)

## TLDR TODOs
all necessary before merge
- [x] Fix ID asserts
- [x] discuss best way to do mercury url fetch
- [ ] double-check `Event::get_global_id()` - want it to be as fast as possible, especially in release. Can we assert/assume some API contracts? or only check them in debug?
- [ ] discuss `Id::id` vs `Id::id_unchecked`
- [ ] would be nice to clean up `webex::types` module, we have a lot of stuff inside one module - can all be reexported globally, but gives people the option of doing (for example) `webex::types::api_responses::RoomsReply`
   - [x] started cleanup with private mod `webex::types::api` containing `trait Gettable`/`ListResult<T>` (for listing items)
   - [ ] Still todo - look at `xyzReply` structs
   - [ ] Can we split it apart further? 