### PR TITLE
Deserialize inputs to serde_json::Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Scott Hutton <shutton@pobox.com>", "Milan Stastny <milan@stastnej.ch>"]
 edition = "2018"
 description = "Interface to Webex Teams REST and WebSocket APIs"

--- a/examples/auto-reply.rs
+++ b/examples/auto-reply.rs
@@ -1,4 +1,5 @@
 use std::env;
+use webex::types::MessageId;
 
 const BOT_ACCESS_TOKEN: &str = "BOT_ACCESS_TOKEN";
 const BOT_EMAIL: &str = "BOT_EMAIL";
@@ -39,7 +40,10 @@ async fn main() {
             if let Some(activity) = &event.data.activity {
                 if activity.verb.as_str() == "post" {
                     // The event stream doesn't contain the message -- you have to go fetch it
-                    if let Ok(msg) = webex.get_message(activity.id.as_str()).await {
+                    if let Ok(msg) = webex
+                        .get_message(&MessageId::from(activity.id.clone()))
+                        .await
+                    {
                         match &msg.person_email {
                             // Reply as long as it doesn't appear to be our own message
                             // In practice, this shouldn't happen since bots can't see messages

--- a/src/types.rs
+++ b/src/types.rs
@@ -351,7 +351,10 @@ pub struct Activity {
 impl Activity {
     #[must_use]
     pub fn get_message_id(&self) -> MessageId {
-        MessageId::new_with_cluster(self.id.clone(), self.target.as_ref().map(Target::get_cluster))
+        MessageId::new_with_cluster(
+            self.id.clone(),
+            self.target.as_ref().map(Target::get_cluster),
+        )
     }
 }
 
@@ -382,7 +385,14 @@ impl MessageId {
             Ok(_) => base64::encode(format!("ciscospark://{}/MESSAGE/{}", cluster, id)),
             Err(_) => id,
         };
-        debug_assert!(String::from_utf8(base64::decode(&id).unwrap()).unwrap().split('/').nth(3).unwrap() == "MESSAGE");
+        debug_assert!(
+            String::from_utf8(base64::decode(&id).unwrap())
+                .unwrap()
+                .split('/')
+                .nth(3)
+                .unwrap()
+                == "MESSAGE"
+        );
         Self { id }
     }
     #[must_use]
@@ -498,7 +508,7 @@ pub struct AttachmentAction {
     pub message_id: Option<String>,
     /// The action's inputs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub inputs: Option<HashMap<String, String>>,
+    pub inputs: Option<HashMap<String, serde_json::Value>>,
     /// The ID of the person who performed the action.
     #[serde(rename = "personId", skip_serializing_if = "Option::is_none")]
     pub person_id: Option<String>,


### PR DESCRIPTION
Linux client creates:
```json
{
  "id": "Y2lzY29zcGFyazovL3VzL0FUVEFDSE1FTlRfQUNUSU9OLzAyZTc5ZjAwLWI4ZWMtMTFlZC05ZmNlLTc3MGU5NGFlMDhhZQ",
  "type": "submit",
  "messageId": "Y2lzY29zcGFyazovL3VzL01FU1NBR0UvZmNmMGZhYjAtYjhlYi0xMWVkLWE3YjItNTExM2NmOTVmOWEw",
  "inputs": {
    "action": "cpds",
    "P3LV1TA": false,
    "P64M9NM": false,
    "P8GCCB6": false,
    "PBX364Z": false,
    "PGONZ1B": false,
    "PTWDV9A": false,
    "PW6XP57": false,
    "PWZ87CW": false,
    "PXG54K9": true,
    "subscription": "Test"
  },
  "personId": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS8zYWRjOGI1Yy01NmE1LTQ5ZDEtYWRkMy1mNGZjZjg0MGFhN2Q",
  "roomId": "Y2lzY29zcGFyazovL3VzL1JPT00vYmI1MDFjNDctYzMwZC0zNWRmLWIzYjMtYWU2N2FmYjhkN2U0",
  "created": "2023-03-02T11:18:51.888Z"
}
```
And this is what the mobile client creates
```json
{
  "id": "Y2lzY29zcGFyazovL3VzL0FUVEFDSE1FTlRfQUNUSU9OL2Q2ZTQ2YjgwLWI4ZWMtMTFlZC1iOTdiLWJkNWM4YmViMTA4Nw",
  "type": "submit",
  "messageId": "Y2lzY29zcGFyazovL3VzL01FU1NBR0UvZDA2YTE4NDAtYjhlYy0xMWVkLWIzNGEtNzlmYjliNDNlYTky",
  "inputs": {
    "action": "cpds",
    "PWZ87CW": "false",
    "P64M9NM": "false",
    "P3LV1TA": "false",
    "PXG54K9": "true",
    "PW6XP57": "false",
    "P8GCCB6": "false",
    "subscription": "test",
    "PBX364Z": "false",
    "PGONZ1B": "false",
    "PTWDV9A": "false"
  },
  "personId": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS8zYWRjOGI1Yy01NmE1LTQ5ZDEtYWRkMy1mNGZjZjg0MGFhN2Q",
  "roomId": "Y2lzY29zcGFyazovL3VzL1JPT00vYmI1MDFjNDctYzMwZC0zNWRmLWIzYjMtYWU2N2FmYjhkN2U0",
  "created": "2023-03-02T11:24:47.544Z"
}
```