### PR TITLE
make ecm_supported_storage_providers field Optional 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "0.7.1"
+version = "0.8.0"
 authors = [
     "Scott Hutton <shutton@pobox.com>",
     "Milan Stastny <milan@stastnej.ch>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "webex"
-version = "0.7.0"
-authors = ["Scott Hutton <shutton@pobox.com>", "Milan Stastny <milan@stastnej.ch>", "Abel Shields <abel@uucp.org.uk>"]
+version = "0.7.1"
+authors = [
+    "Scott Hutton <shutton@pobox.com>",
+    "Milan Stastny <milan@stastnej.ch>",
+    "Abel Shields <abel@uucp.org.uk>",
+]
 edition = "2018"
 description = "Interface to Webex Teams REST and WebSocket APIs"
 keywords = ["webex", "spark"]

--- a/src/types.rs
+++ b/src/types.rs
@@ -306,7 +306,7 @@ pub struct DeviceData {
     pub client_messaging_giphy: Option<String>,
     pub client_messaging_link_preview: Option<String>,
     pub ecm_enabled_for_all_users: Option<bool>,
-    pub ecm_supported_storage_providers: Vec<String>,
+    pub ecm_supported_storage_providers: Option<Vec<String>>,
     pub default_ecm_microsoft_cloud: Option<String>,
     pub ecm_microsoft_tenant: Option<String>,
     pub ecm_screen_capture_feature_allowed: Option<bool>,


### PR DESCRIPTION
`webex-rust` started panicking a few days ago when deserializing `DeviceData` because the Webex API stopped providing the `ecm_supported_storage_providers` field. This small change makes it Option, like all the other fields in `DeviceData`, and restores functionality.