### PR TITLE
Me endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "0.7.1"
+version = "0.7.2"
 authors = [
     "Scott Hutton <shutton@pobox.com>",
     "Milan Stastny <milan@stastnej.ch>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "webex"
-version = "0.7.0"
-authors = ["Scott Hutton <shutton@pobox.com>", "Milan Stastny <milan@stastnej.ch>", "Abel Shields <abel@uucp.org.uk>"]
+version = "0.7.1"
+authors = [
+    "Scott Hutton <shutton@pobox.com>",
+    "Milan Stastny <milan@stastnej.ch>",
+    "Abel Shields <abel@uucp.org.uk>",
+]
 edition = "2018"
 description = "Interface to Webex Teams REST and WebSocket APIs"
 keywords = ["webex", "spark"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,6 +632,22 @@ impl Webex {
         self.get(id).await
     }
 
+    /// Get the Person for the current user
+    /// # Errors
+    /// * [`ErrorKind::Limited`] - returned on HTTP 423/429 with an optional Retry-After.
+    /// * [`ErrorKind::Status`] | [`ErrorKind::StatusText`] - returned when the request results in a non-200 code.
+    /// * [`ErrorKind::Json`] - returned when your input object cannot be serialized, or the return
+    /// value cannot be deserialised. (If this happens, this is a library bug and should be
+    /// reported.)
+    /// * [`ErrorKind::UTF8`] - returned when the request returns non-UTF8 code.
+    pub async fn me(&self) -> Result<Person, Error> {
+        let rest_method = "people/me".to_string();
+        self.client
+            .api_get::<Person>(rest_method.as_str(), Authorization::Bearer(&self.token))
+            .await
+            .chain_err(|| "Failed to get own details")
+    }
+
     /// Send a message to a user or room
     ///
     /// # Arguments

--- a/src/types.rs
+++ b/src/types.rs
@@ -306,7 +306,7 @@ pub struct DeviceData {
     pub client_messaging_giphy: Option<String>,
     pub client_messaging_link_preview: Option<String>,
     pub ecm_enabled_for_all_users: Option<bool>,
-    pub ecm_supported_storage_providers: Vec<String>,
+    pub ecm_supported_storage_providers: Option<Vec<String>>,
     pub default_ecm_microsoft_cloud: Option<String>,
     pub ecm_microsoft_tenant: Option<String>,
     pub ecm_screen_capture_feature_allowed: Option<bool>,


### PR DESCRIPTION
When using as an integration (not a bot), it is useful to retrieve the details of the logged in user.
For example to identify is a received message is from ourselves.
This adds a method to retrieve the current logged in user.

NB: this makes sense to pull only after #21, for the version bumps. Sorry ;)