### PR TITLE
fix: drop severity of unhandled event message - #26

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -626,7 +626,7 @@ impl Event {
             "janus.user_sessions" => ActivityType::Janus,
             //"apheleia.subscription_update" ??
             e => {
-                log::error!("Unknown data.event_type `{}`, returning Unknown", e);
+                log::debug!("Unknown data.event_type `{}`, returning Unknown", e);
                 ActivityType::Unknown(e.to_string())
             }
         }


### PR DESCRIPTION
Proposal to drop the severity of unknown events, as they are frequent and pollute the logs