### PR TITLE
(fix) Reset connection on tungstenite io error

### DIFF
--- a/src/adaptive_card.rs
+++ b/src/adaptive_card.rs
@@ -775,9 +775,9 @@ impl CardElement {
     /// Set Placeholder
     pub fn set_placeholder(&mut self, s: Option<String>) -> Self {
         match self {
-            CardElement::InputText { placeholder, .. }
-            | CardElement::InputNumber { placeholder, .. }
-            | CardElement::InputDate { placeholder, .. } => {
+            Self::InputText { placeholder, .. }
+            | Self::InputNumber { placeholder, .. }
+            | Self::InputDate { placeholder, .. } => {
                 *placeholder = s;
             }
             _ => {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -52,9 +52,9 @@ impl DeviceAuthenticator {
     ///
     /// For more details: <https://developer.webex.com/docs/integrations>.
     #[must_use]
-    pub fn new(id: &str, secret: &str) -> DeviceAuthenticator {
+    pub fn new(id: &str, secret: &str) -> Self {
         let client = RestClient::new();
-        DeviceAuthenticator {
+        Self {
             client_id: id.to_string(),
             client_secret: secret.to_string(),
             client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![deny(missing_docs)]
 #![deny(clippy::all, clippy::pedantic, clippy::nursery)]
-// clippy::use_self fixed in https://github.com/rust-lang/rust-clippy/pull/9454
-// TODO: remove this when clippy bug fixed in stable
-#![allow(clippy::use_self)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, deny(warnings))]
@@ -254,11 +251,11 @@ where
 }
 
 impl RestClient {
-    /// Creates a new RestClient
-    pub fn new() -> RestClient {
+    /// Creates a new `RestClient`
+    pub fn new() -> Self {
         let https = HttpsConnector::new();
         let web_client = Client::builder().build::<_, hyper::Body>(https);
-        RestClient {
+        Self {
             host_prefix: HashMap::new(),
             web_client,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ impl WebexEventStream {
                 }
                 // Didn't time out
                 Ok(next_result) => match next_result {
+                    None => continue,
                     Some(msg) => match msg {
                         Ok(msg) => {
                             if let Some(h_msg) = self.handle_message(msg)? {
@@ -149,7 +150,6 @@ impl WebexEventStream {
                             .into())
                         }
                     },
-                    None => continue,
                 },
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -613,8 +613,7 @@ impl Event {
                                 activity_type
                             );
                             ActivityType::Unknown(format!(
-                                "conversation.activity.{}",
-                                activity_type
+                                "conversation.activity.{activity_type}"
                             ))
                         }
                     }


### PR DESCRIPTION
Repeated error:
`Event stream (open: true) error: Error(Tungstenite(Io(Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" }), "Error getting next_result"), State { next_error: None, backtrace: InternalBacktrace { backtrace: None } })`
Stream stops working after this error and needs to be restarted.

According to [tungstenite docs](https://docs.rs/tungstenite/latest/tungstenite/error/enum.Error.html#variant.Io), IO error is generally an error with the underlying connection and "should probably be considered fatal"