### PR TITLE
fix!: prevent racing of event stream connection between devices (fix #34)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "0.8.0"
+version = "1.0.0"
 authors = [
     "Scott Hutton <shutton@pobox.com>",
     "Milan Stastny <milan@stastnej.ch>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webex"
-version = "1.0.0"
+version = "0.9.0"
 authors = [
     "Scott Hutton <shutton@pobox.com>",
     "Milan Stastny <milan@stastnej.ch>",

--- a/src/types.rs
+++ b/src/types.rs
@@ -299,18 +299,6 @@ impl fmt::Display for DeviceData {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[allow(missing_docs)]
-pub struct DeviceFeatures {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub developer: Option<Vec<DeviceFeatureData>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entitlement: Option<Vec<DeviceFeatureData>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<Vec<DeviceFeatureData>>,
-}
-
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct Authorization {
@@ -527,9 +515,7 @@ impl Event {
                                 "Unknown activity type `{}`, returning Unknown",
                                 activity_type
                             );
-                            ActivityType::Unknown(format!(
-                                "conversation.activity.{activity_type}"
-                            ))
+                            ActivityType::Unknown(format!("conversation.activity.{activity_type}"))
                         }
                     }
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,8 +4,8 @@
 use crate::{adaptive_card::AdaptiveCard, error, error::ResultExt};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::{collections::HashMap, fmt};
 use uuid::Uuid;
 
 pub(crate) use api::{Gettable, ListResult};
@@ -290,6 +290,25 @@ pub struct DeviceData {
     pub name: Option<String>,
     pub system_name: Option<String>,
     pub system_version: Option<String>,
+}
+
+impl fmt::Display for DeviceData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "name: {:?}, device_name: {:?}, device_type: {:?}, model: {:?}, system_name: {:?}, system_version: {:?}, url: {:?}",
+        self.name, self.device_name, self.device_type, self.model, self.system_name, self.system_version, self.url)
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(missing_docs)]
+pub struct DeviceFeatures {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub developer: Option<Vec<DeviceFeatureData>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entitlement: Option<Vec<DeviceFeatureData>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<Vec<DeviceFeatureData>>,
 }
 
 #[allow(missing_docs)]


### PR DESCRIPTION
This adds the capability to provide the name of the webex device this crate uses. If existing, the latest device with that name will be used. If it doesn't, a new one will be created with that name.

A default name is provided to ensure backwards compatibility while still fixing the race condition with official clients.

BREAKING CHANGE: existing webex devices that were not created by this crate will no longer be selected when creating the event stram. This is the intent of this fix but represents a change in behaviour.