### PR TITLE
38-fix-glob_re_export-sgrimee

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 //! Ways to authenticate with the Webex API
 
-use crate::{Authorization, RequestBody, RestClient};
+use crate::{AuthorizationType, RequestBody, RestClient};
 use hyper::StatusCode;
 use serde::Deserialize;
 use tokio::time::{self, Duration, Instant};
@@ -74,7 +74,7 @@ impl DeviceAuthenticator {
                     media_type: "application/x-www-form-urlencoded; charset=utf-8",
                     content: serde_urlencoded::to_string(params)?,
                 },
-                Authorization::None,
+                AuthorizationType::None,
             )
             .await?;
         Ok(verification_token)
@@ -109,7 +109,7 @@ impl DeviceAuthenticator {
                         media_type: "application/x-www-form-urlencoded; charset=utf-8",
                         content: serde_urlencoded::to_string(params)?,
                     },
-                    Authorization::Basic {
+                    AuthorizationType::Basic {
                         username: &self.client_id,
                         password: &self.client_secret,
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@ pub mod auth;
 use error::{Error, ErrorKind, ResultExt};
 
 use crate::adaptive_card::AdaptiveCard;
-use crate::types::Attachment;
 use base64::{engine::general_purpose as bas64enc, Engine as _};
 use futures::{future::try_join_all, try_join};
 use futures_util::{SinkExt, StreamExt};

--- a/src/types.rs
+++ b/src/types.rs
@@ -486,6 +486,10 @@ impl Event {
     /// Get the type of resource the event corresponds to.
     /// Also contains details about the event action for some event types.
     /// For more details, check [`ActivityType`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if conversation activity is not set
     #[must_use]
     pub fn activity_type(&self) -> ActivityType {
         match self.data.event_type.as_str() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -258,7 +258,7 @@ pub(crate) struct EmptyReply {}
 /// API Error
 #[allow(missing_docs)]
 #[derive(Deserialize, Serialize, Debug)]
-pub struct Error {
+pub struct DeviceError {
     pub description: String,
 }
 
@@ -270,7 +270,7 @@ pub(crate) struct DevicesReply {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub errors: Option<Vec<Error>>,
+    pub errors: Option<Vec<DeviceError>>,
     #[serde(rename = "trackingId", skip_serializing_if = "Option::is_none")]
     pub tracking_id: Option<String>,
 }


### PR DESCRIPTION
Attempt to address issue #38.

4 commits:
- address shadowing of Attachment struct by removing the explicit use
- address shadowing of Authorization by renaming the private enum to AuthorizationType
- address shadowing of Error by renaming the crate Error to DeviceError, as it seems to be used only there. This is a breaking API change though, so LMK if you prefer to address this some other way. If there is a need for a crate Error type, it would be nice to give it a more explicit name?
- the last commit has a few minor fixes to address clippy warnings