### PR TITLE
List with params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tungstenite = "0.19.0"
 url = "2.2"
 lazy_static = "1.4.0"
 serde_html_form = "0.2.2"
+serde_with = { version = "3.4.0", features = ["macros"] }
 
 [dependencies.chrono]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tokio-native-tls = "0.3"
 tungstenite = "0.19.0"
 url = "2.2"
 lazy_static = "1.4.0"
-serde_urlencoded = "0.7.1"
+serde_html_form = "0.2.2"
 
 [dependencies.chrono]
 version = "0.4"

--- a/docs.sh
+++ b/docs.sh
@@ -1,0 +1,2 @@
+cargo watch -x doc &
+cd target/docs && python3 -m http.server

--- a/docs.sh
+++ b/docs.sh
@@ -1,2 +1,0 @@
-cargo watch -x doc &
-cd target/docs && python3 -m http.server

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -72,7 +72,7 @@ impl DeviceAuthenticator {
                 "device/authorize",
                 RequestBody {
                     media_type: "application/x-www-form-urlencoded; charset=utf-8",
-                    content: serde_urlencoded::to_string(params)?,
+                    content: serde_html_form::to_string(params)?,
                 },
                 AuthorizationType::None,
             )
@@ -107,7 +107,7 @@ impl DeviceAuthenticator {
                     "device/token",
                     RequestBody {
                         media_type: "application/x-www-form-urlencoded; charset=utf-8",
-                        content: serde_urlencoded::to_string(params)?,
+                        content: serde_html_form::to_string(params)?,
                     },
                     AuthorizationType::Basic {
                         username: &self.client_id,

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ error_chain! {
     foreign_links {
         Io(std::io::Error);
         Json(SerdeError);
-        HtmlEncoding(SerdeHtmlError);
+        FormEncoding(SerdeHtmlError);
         UTF8(std::str::Utf8Error);
         Hyper(HyperError);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,12 @@
 use hyper::{Error as HyperError, StatusCode};
 use serde_json::error::Error as SerdeError;
+use serde_html_form::ser::Error as SerdeHtmlError;
 
 error_chain! {
     foreign_links {
         Io(std::io::Error);
         Json(SerdeError);
-        FormEncoding(serde_urlencoded::ser::Error);
+        HtmlEncoding(SerdeHtmlError);
         UTF8(std::str::Utf8Error);
         Hyper(HyperError);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use hyper::{Error as HyperError, StatusCode};
-use serde_json::error::Error as SerdeError;
 use serde_html_form::ser::Error as SerdeHtmlError;
+use serde_json::error::Error as SerdeError;
 
 error_chain! {
     foreign_links {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use futures::{future::try_join_all, try_join};
 use futures_util::{SinkExt, StreamExt};
 use hyper::{body::HttpBody, client::HttpConnector, Body, Client, Request};
 use hyper_tls::HttpsConnector;
-use log::*;
+use log::{debug, error, trace, warn};
 use serde::de::DeserializeOwned;
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,10 +737,8 @@ impl Webex {
         let rest_method = format!(
             "{}?{}",
             T::API_ENDPOINT,
-            serde_html_form::to_string(&list_params)?
+            serde_html_form::to_string(list_params)?
         );
-        drop(list_params); // Keep the future Send-safe (apparently list_params can't be held
-                           // across an await)
         self.client
             .api_get::<ListResult<T>>(&rest_method, AuthorizationType::Bearer(&self.token))
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::option_if_let_else)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/webex/0.2.0/webex/")]
+#![doc(html_root_url = "https://docs.rs/webex/latest/webex/")]
 
 //! # webex-rust
 //!
@@ -48,7 +48,7 @@ use futures_util::{SinkExt, StreamExt};
 use hyper::{body::HttpBody, client::HttpConnector, Body, Client, Request};
 use hyper_tls::HttpsConnector;
 use log::{debug, trace, warn};
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
     hash::{self, Hasher},
@@ -722,6 +722,119 @@ impl Webex {
             .await
             .map(|result| result.items)
             .chain_err(|| format!("Failed to list {}", std::any::type_name::<T>()))
+    }
+
+    /// List resources of a type, with parameters
+    pub async fn list_with_params<T: Gettable + DeserializeOwned>(&self, list_params: T::ListParams<'_>) -> Result<Vec<T>, Error> {
+        let rest_method = format!("{}?{}", T::API_ENDPOINT, serde_html_form::to_string(list_params)?);
+        self.api_get::<ListResult<T>>(&rest_method)
+            .await
+            .map(|result| result.items)
+            .chain_err(|| format!("Failed to list {}", std::any::type_name::<T>()))
+    }
+
+    /******************************************************************
+     * Low-level API.  These calls are chained to build various
+     * high-level calls like "get_message"
+     ******************************************************************/
+
+    async fn api_get<T: DeserializeOwned>(&self, rest_method: &str) -> Result<T, Error> {
+        let body: Option<String> = None;
+        self.rest_api("GET", rest_method, body).await
+    }
+
+    async fn api_delete(&self, rest_method: &str) -> Result<(), Error> {
+        let body: Option<String> = None;
+        self.rest_api("DELETE", rest_method, body).await
+    }
+
+    async fn api_post<T: DeserializeOwned, U: Serialize + Send>(
+        &self,
+        rest_method: &str,
+        body: U,
+    ) -> Result<T, Error> {
+        self.rest_api("POST", rest_method, Some(body)).await
+    }
+
+    async fn rest_api<T: DeserializeOwned, U: Serialize + Send>(
+        &self,
+        http_method: &str,
+        rest_method: &str,
+        body: Option<U>,
+    ) -> Result<T, Error> {
+        let reply = self
+            .call_web_api_raw(http_method, rest_method, body)
+            .await?;
+        let mut reply_str = reply.as_str();
+        if reply_str.is_empty() {
+            reply_str = "null";
+        }
+        serde_json::from_str(reply_str).map_err(|e| {
+            debug!("Couldn't parse reply for {} call: {}", rest_method, e);
+            debug!("Source JSON: `{}`", reply_str);
+            Error::with_chain(e, "failed to parse reply")
+        })
+    }
+
+    async fn call_web_api_raw<T: Serialize + Send>(
+        &self,
+        http_method: &str,
+        rest_method: &str,
+        body: Option<T>,
+    ) -> Result<String, Error> {
+        let default_prefix = String::from(REST_HOST_PREFIX);
+        let rest_method_trimmed = rest_method.split('?').next().unwrap_or(rest_method);
+        let prefix = self
+            .client
+            .host_prefix
+            .get(rest_method_trimmed)
+            .unwrap_or(&default_prefix);
+        let url = format!("{prefix}/{rest_method}");
+        debug!("Calling {} {:?}", http_method, url);
+        let mut builder = Request::builder()
+            .method(http_method)
+            .uri(url)
+            .header("Authorization", &self.token);
+        if body.is_some() {
+            builder = builder.header("Content-Type", "application/json");
+        }
+        let body = match body {
+            Some(obj) => Body::from(serde_json::to_string(&obj)?),
+            None => Body::empty(),
+        };
+        let req = builder.body(body).expect("request builder");
+        match self.client.web_client.request(req).await {
+            Ok(mut resp) => {
+                let mut reply = String::new();
+                while let Some(chunk) = resp.body_mut().data().await {
+                    use std::str;
+
+                    let chunk = &chunk?;
+                    let strchunk = str::from_utf8(&chunk)?;
+                    reply.push_str(strchunk);
+                }
+                match resp.status() {
+                    hyper::StatusCode::LOCKED | hyper::StatusCode::TOO_MANY_REQUESTS => {
+                        let retry_after = resp
+                            .headers()
+                            .get("Retry-After")
+                            .and_then(|s| s.to_str().ok())
+                            .and_then(|t| t.parse::<i64>().ok());
+                        warn!(
+                            "Limited calling {} {}/{}",
+                            http_method, prefix, rest_method_trimmed
+                        );
+                        debug!("Retry-After: {:?}", retry_after);
+                        Err(ErrorKind::Limited(resp.status(), retry_after).into())
+                    }
+                    status if !status.is_success() => {
+                        Err(ErrorKind::StatusText(resp.status(), reply).into())
+                    }
+                    _ => Ok(reply),
+                }
+            }
+            Err(e) => Err(Error::with_chain(e, "request failed")),
+        }
     }
 
     async fn get_devices(&self) -> Result<Vec<DeviceData>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ use futures_util::{SinkExt, StreamExt};
 use hyper::{body::HttpBody, client::HttpConnector, Body, Client, Request};
 use hyper_tls::HttpsConnector;
 use log::{debug, trace, warn};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
     hash::{self, Hasher},
@@ -725,116 +725,20 @@ impl Webex {
     }
 
     /// List resources of a type, with parameters
-    pub async fn list_with_params<T: Gettable + DeserializeOwned>(&self, list_params: T::ListParams<'_>) -> Result<Vec<T>, Error> {
-        let rest_method = format!("{}?{}", T::API_ENDPOINT, serde_html_form::to_string(list_params)?);
-        self.api_get::<ListResult<T>>(&rest_method)
+    pub async fn list_with_params<T: Gettable + DeserializeOwned>(
+        &self,
+        list_params: T::ListParams<'_>,
+    ) -> Result<Vec<T>, Error> {
+        let rest_method = format!(
+            "{}?{}",
+            T::API_ENDPOINT,
+            serde_html_form::to_string(list_params)?
+        );
+        self.client
+            .api_get::<ListResult<T>>(&rest_method, Authorization::Bearer(&self.token))
             .await
             .map(|result| result.items)
             .chain_err(|| format!("Failed to list {}", std::any::type_name::<T>()))
-    }
-
-    /******************************************************************
-     * Low-level API.  These calls are chained to build various
-     * high-level calls like "get_message"
-     ******************************************************************/
-
-    async fn api_get<T: DeserializeOwned>(&self, rest_method: &str) -> Result<T, Error> {
-        let body: Option<String> = None;
-        self.rest_api("GET", rest_method, body).await
-    }
-
-    async fn api_delete(&self, rest_method: &str) -> Result<(), Error> {
-        let body: Option<String> = None;
-        self.rest_api("DELETE", rest_method, body).await
-    }
-
-    async fn api_post<T: DeserializeOwned, U: Serialize + Send>(
-        &self,
-        rest_method: &str,
-        body: U,
-    ) -> Result<T, Error> {
-        self.rest_api("POST", rest_method, Some(body)).await
-    }
-
-    async fn rest_api<T: DeserializeOwned, U: Serialize + Send>(
-        &self,
-        http_method: &str,
-        rest_method: &str,
-        body: Option<U>,
-    ) -> Result<T, Error> {
-        let reply = self
-            .call_web_api_raw(http_method, rest_method, body)
-            .await?;
-        let mut reply_str = reply.as_str();
-        if reply_str.is_empty() {
-            reply_str = "null";
-        }
-        serde_json::from_str(reply_str).map_err(|e| {
-            debug!("Couldn't parse reply for {} call: {}", rest_method, e);
-            debug!("Source JSON: `{}`", reply_str);
-            Error::with_chain(e, "failed to parse reply")
-        })
-    }
-
-    async fn call_web_api_raw<T: Serialize + Send>(
-        &self,
-        http_method: &str,
-        rest_method: &str,
-        body: Option<T>,
-    ) -> Result<String, Error> {
-        let default_prefix = String::from(REST_HOST_PREFIX);
-        let rest_method_trimmed = rest_method.split('?').next().unwrap_or(rest_method);
-        let prefix = self
-            .client
-            .host_prefix
-            .get(rest_method_trimmed)
-            .unwrap_or(&default_prefix);
-        let url = format!("{prefix}/{rest_method}");
-        debug!("Calling {} {:?}", http_method, url);
-        let mut builder = Request::builder()
-            .method(http_method)
-            .uri(url)
-            .header("Authorization", &self.token);
-        if body.is_some() {
-            builder = builder.header("Content-Type", "application/json");
-        }
-        let body = match body {
-            Some(obj) => Body::from(serde_json::to_string(&obj)?),
-            None => Body::empty(),
-        };
-        let req = builder.body(body).expect("request builder");
-        match self.client.web_client.request(req).await {
-            Ok(mut resp) => {
-                let mut reply = String::new();
-                while let Some(chunk) = resp.body_mut().data().await {
-                    use std::str;
-
-                    let chunk = &chunk?;
-                    let strchunk = str::from_utf8(&chunk)?;
-                    reply.push_str(strchunk);
-                }
-                match resp.status() {
-                    hyper::StatusCode::LOCKED | hyper::StatusCode::TOO_MANY_REQUESTS => {
-                        let retry_after = resp
-                            .headers()
-                            .get("Retry-After")
-                            .and_then(|s| s.to_str().ok())
-                            .and_then(|t| t.parse::<i64>().ok());
-                        warn!(
-                            "Limited calling {} {}/{}",
-                            http_method, prefix, rest_method_trimmed
-                        );
-                        debug!("Retry-After: {:?}", retry_after);
-                        Err(ErrorKind::Limited(resp.status(), retry_after).into())
-                    }
-                    status if !status.is_success() => {
-                        Err(ErrorKind::StatusText(resp.status(), reply).into())
-                    }
-                    _ => Ok(reply),
-                }
-            }
-            Err(e) => Err(Error::with_chain(e, "request failed")),
-        }
     }
 
     async fn get_devices(&self) -> Result<Vec<DeviceData>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use futures::{future::try_join_all, try_join};
 use futures_util::{SinkExt, StreamExt};
 use hyper::{body::HttpBody, client::HttpConnector, Body, Client, Request};
 use hyper_tls::HttpsConnector;
-use log::{debug, trace, warn};
+use log::*;
 use serde::de::DeserializeOwned;
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
@@ -323,8 +323,8 @@ impl RestClient {
             reply_str = "null";
         }
         serde_json::from_str(reply_str).map_err(|e| {
-            debug!("Couldn't parse reply for {} call: {}", rest_method, e);
-            debug!("Source JSON: `{}`", reply_str);
+            error!("Couldn't parse reply for {} call: {:#?}", rest_method, e);
+            trace!("Source JSON: `{}`", reply_str);
             Error::with_chain(e, "failed to parse reply")
         })
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,30 +20,51 @@ mod api {
         /// Endpoint to query to perform an HTTP GET request with an id (to get an instance), or
         /// without an id (to list them).
         const API_ENDPOINT: &'static str;
+        type ListParams<'a>: serde::Serialize;
     }
+
+    #[derive(crate::types::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct MessageListParams<'a> {
+        room_id: &'a str,
+        //#[serde(skip_serializing_if = "Option::is_none")] // Should be automatic
+        parent_id: Option<&'a str>,
+        #[serde(skip_serializing_if = "<[_]>::is_empty")]
+        mentioned_people: &'a [&'a str],
+        // TODO: before: string, beforeMessage: id, max: number
+    }
+
+    #[derive(crate::types::Serialize)]
+    pub enum Infallible {}
 
     impl Gettable for Message {
         const API_ENDPOINT: &'static str = "messages";
+        type ListParams<'a> = MessageListParams<'a>;
     }
 
     impl Gettable for Organization {
         const API_ENDPOINT: &'static str = "organizations";
+        type ListParams<'a> = Option<Infallible>;
     }
 
     impl Gettable for AttachmentAction {
         const API_ENDPOINT: &'static str = "attachment/actions";
+        type ListParams<'a> = Option<Infallible>;
     }
 
     impl Gettable for Room {
         const API_ENDPOINT: &'static str = "rooms";
+        type ListParams<'a> = Option<Infallible>;
     }
 
     impl Gettable for Person {
         const API_ENDPOINT: &'static str = "people";
+        type ListParams<'a> = Option<Infallible>;
     }
 
     impl Gettable for Team {
         const API_ENDPOINT: &'static str = "teams";
+        type ListParams<'a> = Option<Infallible>;
     }
 
     #[derive(crate::types::Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,7 +95,7 @@ pub struct Room {
 
 #[derive(crate::types::Serialize)]
 #[serde(rename_all = "lowercase")]
-/// Sorting order for RoomListParams
+/// Sorting order for `RoomListParams`
 pub enum SortRoomsBy {
     /// room id
     Id,

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,6 +4,7 @@
 use crate::{adaptive_card::AdaptiveCard, error, error::ResultExt};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::convert::TryFrom;
 use std::{collections::HashMap, fmt};
 use uuid::Uuid;
@@ -12,7 +13,10 @@ pub(crate) use api::{Gettable, ListResult};
 
 mod api {
     //! Private crate to hold all types that the user shouldn't have to interact with.
-    use super::{AttachmentAction, Message, MessageListParams, Organization, Person, Room, Team};
+    use super::{
+        AttachmentAction, Message, MessageListParams, Organization, Person, Room, RoomListParams,
+        Team,
+    };
 
     /// Trait for API types. Has to be public due to trait bounds limitations on webex API, but hidden
     /// in a private crate so users don't see it.
@@ -43,7 +47,7 @@ mod api {
 
     impl Gettable for Room {
         const API_ENDPOINT: &'static str = "rooms";
-        type ListParams<'a> = Option<Infallible>;
+        type ListParams<'a> = RoomListParams<'a>;
     }
 
     impl Gettable for Person {
@@ -63,6 +67,7 @@ mod api {
 }
 
 /// Webex Teams room information
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Room {
@@ -79,7 +84,6 @@ pub struct Room {
     /// Whether the room is moderated (locked) or not.
     pub is_locked: bool,
     /// The ID for the team with which this room is associated.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub team_id: Option<String>,
     /// The date and time of the room's last activity.
     pub last_activity: String,
@@ -87,6 +91,41 @@ pub struct Room {
     pub creator_id: String,
     /// The date and time the room was created.
     pub created: String,
+}
+
+#[derive(crate::types::Serialize)]
+#[serde(rename_all = "lowercase")]
+/// Sorting order for RoomListParams
+pub enum SortRoomsBy {
+    /// room id
+    Id,
+    /// last activity timestamp
+    LastActivity,
+    /// created timestamp
+    Created,
+}
+
+#[skip_serializing_none]
+#[derive(Default, crate::types::Serialize)]
+#[serde(rename_all = "camelCase")]
+/// Parameters for listing rooms
+pub struct RoomListParams<'a> {
+    /// List rooms in a team, by ID.
+    pub team_id: Option<&'a str>,
+    /// List rooms by type. Cannot be set in combination with orgPublicSpaces.
+    #[serde(rename = "type")]
+    pub room_type: Option<RoomType>,
+    /// Shows the org's public spaces joined and unjoined. When set the result list is sorted by the madePublic timestamp.
+    pub org_public_spaces: Option<bool>,
+    /// Filters rooms, that were made public after this time. See madePublic timestamp
+    pub from: Option<&'a str>,
+    /// Filters rooms, that were made public before this time. See madePublic timestamp
+    pub to: Option<&'a str>,
+    /// Sort results. Cannot be set in combination with orgPublicSpaces.
+    pub sort_by: Option<SortRoomsBy>,
+    /// Limit the maximum number of rooms in the response.
+    /// Default: 100
+    pub max: Option<u32>,
 }
 
 /// Holds details about the organization an account belongs to.
@@ -101,6 +140,7 @@ pub struct Organization {
     pub created: String,
 }
 
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug)]
 /// Holds details about a team that includes the account.
 pub struct Team {
@@ -111,7 +151,6 @@ pub struct Team {
     /// Date and time the team was created
     pub created: String,
     /// Team description
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 
@@ -161,36 +200,29 @@ pub enum Destination {
 }
 
 /// Outgoing message
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageOut {
     /// The parent message to reply to.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
     /// The room ID of the message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The person ID of the recipient when sending a private 1:1 message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_id: Option<String>,
     /// The email address of the recipient when sending a private 1:1 message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_email: Option<String>,
     // TODO - should we use globalIDs? We should check this field before the message is sent
     // rolls up room_id, to_person_id, and to_person_email all in one field :)
     //#[serde(flatten)]
     //pub deliver_to: Option<Destination>,
     /// The message, in plain text. If markdown is specified this parameter may be optionally used to provide alternate text for UI clients that do not support rich text. The maximum message length is 7439 bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// The message, in Markdown format. The maximum message length is 7439 bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub markdown: Option<String>,
     /// The public URL to a binary file to be posted into the room. Only one file is allowed per message. Uploaded files are automatically converted into a format that all Webex Teams clients can render. For the supported media types and the behavior of uploads, see the [Message Attachments Guide](https://developer.webex.com/docs/api/basics#message-attachments).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<String>>,
     /// Content attachments to attach to the message. Only one card per message is supported.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<Attachment>>,
 }
 
@@ -206,62 +238,47 @@ pub enum RoomType {
 }
 
 /// Webex Teams message information
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Message {
     /// The unique identifier for the message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// The room ID of the message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The room type.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_type: Option<RoomType>,
     /// The person ID of the recipient when sending a private 1:1 message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_id: Option<String>,
     /// The email address of the recipient when sending a private 1:1 message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub to_person_email: Option<String>,
     /// The message, in plain text. If markdown is specified this parameter may be optionally used to provide alternate text for UI clients that do not support rich text.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// The message, in Markdown format.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub markdown: Option<String>,
     /// The text content of the message, in HTML format. This read-only property is used by the Webex Teams clients.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub html: Option<String>,
     /// Public URLs for files attached to the message. For the supported media types and the behavior of file uploads, see Message Attachments.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<String>>,
     /// The person ID of the message author.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub person_id: Option<String>,
     /// The email address of the message author.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub person_email: Option<String>,
     /// People IDs for anyone mentioned in the message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mentioned_people: Option<Vec<String>>,
     /// Group names for the groups mentioned in the message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mentioned_groups: Option<Vec<String>>,
     /// Message content attachments attached to the message.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Vec<Attachment>>,
     /// The date and time the message was created.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
     /// The date and time the message was updated, if it was edited.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub updated: Option<String>,
     /// The ID of the "parent" message (the start of the reply chain)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(crate::types::Serialize)]
 #[serde(rename_all = "camelCase")]
 /// Parameters for listing messages
@@ -310,15 +327,13 @@ pub struct DeviceError {
 }
 
 #[allow(missing_docs)]
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct DevicesReply {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub devices: Option<Vec<DeviceData>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<DeviceError>>,
-    #[serde(rename = "trackingId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "trackingId")]
     pub tracking_id: Option<String>,
 }
 
@@ -391,19 +406,18 @@ pub struct Actor {
 }
 
 #[allow(missing_docs)]
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct EventData {
     pub event_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub actor: Option<Actor>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub conversation_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub activity: Option<Activity>,
 }
 
 #[allow(missing_docs)]
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Activity {
@@ -414,13 +428,9 @@ pub struct Activity {
     pub verb: String,
     pub actor: Actor,
     pub object: Object,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<Target>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_temp_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub encryption_key_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub vector_counters: Option<VectorCounters>,
 }
 
@@ -793,17 +803,14 @@ pub struct Target {
 }
 
 #[allow(missing_docs)]
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Object {
     pub object_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mentions: Option<MiscItems>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inputs: Option<String>,
 }
 
@@ -841,6 +848,7 @@ pub enum AlertType {
 
 /// Returned from [`WebexEventStream::next()`][`crate::WebexEventStream::next()`]. Contains information about the received event.
 #[allow(missing_docs)]
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Event {
@@ -852,7 +860,6 @@ pub struct Event {
     /// Timestamp in milliseconds since epoch.
     pub timestamp: i64,
     pub tracking_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub alert_type: Option<AlertType>,
     pub headers: HashMap<String, String>,
     pub sequence_number: i64,
@@ -870,28 +877,24 @@ pub struct Attachment {
 }
 
 /// Attachment action details
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AttachmentAction {
     /// A unique identifier for the action.
     pub id: String,
     /// The type of action performed.
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub action_type: Option<String>,
     /// The parent message the attachment action was performed on.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
     /// The action's inputs.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub inputs: Option<HashMap<String, serde_json::Value>>,
     /// The ID of the person who performed the action.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub person_id: Option<String>,
     /// The ID of the room the action was performed within.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub room_id: Option<String>,
     /// The date and time the action was created.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
 }
 


### PR DESCRIPTION
This is the same as #25, rebased on master, with merge conflicts resolved, and a correction to make the MessageListParams struct visible to the user of the crate.
Tested in  sgrimee/webex-tui@803aa52a16e3b88ea35ebb4aa3b7a04721b119da, seems to work ok.